### PR TITLE
Add affinity to the checker batch job

### DIFF
--- a/charts/milvus-operator/templates/job.yaml
+++ b/charts/milvus-operator/templates/job.yaml
@@ -9,6 +9,7 @@ spec:
   ttlSecondsAfterFinished: 100
   template:
     spec:
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "chart.checkerServiceAccountName" . | quote }}


### PR DESCRIPTION
The Helm chart `values.yaml` file allows setting affinity for the deployment. This affinity should also carry over to the checker batch job.

We use affinity with a multi-architecture cluster to ensure jobs run on architecture they are built for. The milvus-operator image does not currently have an ARM version, so we need affinity to ensure that it does not attempt to run on ARM nodes, otherwise you end up with random batch job failures if they get scheduled onto inappropriate architecture.