### PR TITLE
fix: align the startup check condition with storage conf fields.

### DIFF
--- a/pkg/controllers/conditions.go
+++ b/pkg/controllers/conditions.go
@@ -114,6 +114,7 @@ type StorageConditionInfo struct {
 	IAMEndpoint string
 	// StorageAccount of azure
 	StorageAccount string
+	UseVirtualHost bool
 }
 
 type checkMinIOFunc = func(args external.CheckMinIOArgs) error
@@ -148,14 +149,15 @@ func GetMinioCondition(ctx context.Context, logger logr.Logger, cli client.Clien
 		ak = info.StorageAccount
 	}
 	err := checkMinIO(external.CheckMinIOArgs{
-		Type:        info.Storage.Type,
-		AK:          ak,
-		SK:          string(secretkey),
-		Endpoint:    info.Storage.Endpoint,
-		Bucket:      info.Bucket,
-		UseSSL:      info.UseSSL,
-		UseIAM:      info.UseIAM,
-		IAMEndpoint: info.IAMEndpoint,
+		Type:           info.Storage.Type,
+		AK:             ak,
+		SK:             string(secretkey),
+		Endpoint:       info.Storage.Endpoint,
+		Bucket:         info.Bucket,
+		UseSSL:         info.UseSSL,
+		UseIAM:         info.UseIAM,
+		IAMEndpoint:    info.IAMEndpoint,
+		UseVirtualHost: info.UseVirtualHost,
 	})
 	if err != nil {
 		return newErrStorageCondResult(v1beta1.ReasonClientErr, err.Error())

--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -487,6 +487,7 @@ func (r *MilvusStatusSyncer) GetMinioCondition(
 		UseIAM:         GetMinioUseIAM(mc.Spec.Conf.Data),
 		IAMEndpoint:    GetMinioIAMEndpoint(mc.Spec.Conf.Data),
 		StorageAccount: GetAzureStorageAccount(mc.Spec.Conf.Data),
+		UseVirtualHost: GetVirtualHostCondition(mc.Spec.Conf.Data),
 	}
 	getter := wrapMinioConditionGetter(ctx, r.logger, r.Client, info)
 	return GetCondition(getter, []string{mc.Spec.Dep.Storage.Endpoint}), nil

--- a/pkg/controllers/utils.go
+++ b/pkg/controllers/utils.go
@@ -388,6 +388,16 @@ func GetMinioSecure(conf map[string]interface{}) bool {
 	return false
 }
 
+func GetVirtualHostCondition(conf map[string]interface{}) bool {
+	fields := []string{"minio", "useVirtualHost"}
+	useVirtualHost, exist := util.GetBoolValue(conf, fields...)
+	if exist {
+		return useVirtualHost
+	}
+
+	return false
+}
+
 func GetMinioBucket(conf map[string]interface{}) string {
 	return GetStringValueWithDefault(conf, defaultBucketName, "minio", "bucketName")
 }

--- a/pkg/external/minio.go
+++ b/pkg/external/minio.go
@@ -16,14 +16,15 @@ import (
 // CheckMinIOArgs is info for acquiring storage condition
 type CheckMinIOArgs struct {
 	// S3 / MinIO
-	Type        string
-	AK          string
-	SK          string
-	Bucket      string
-	Endpoint    string
-	UseSSL      bool
-	UseIAM      bool
-	IAMEndpoint string
+	Type           string
+	AK             string
+	SK             string
+	Bucket         string
+	Endpoint       string
+	UseSSL         bool
+	UseIAM         bool
+	IAMEndpoint    string
+	UseVirtualHost bool
 }
 
 var DependencyCheckTimeout = 5 * time.Second
@@ -40,11 +41,15 @@ func CheckMinIO(args CheckMinIOArgs) error {
 				// minio client cannot recognize aws endpoints with :443
 				endpoint = strings.TrimSuffix(endpoint, ":443")
 			}
+			bucketLookup := minio.BucketLookupPath
+			if args.UseVirtualHost {
+				bucketLookup = minio.BucketLookupDNS
+			}
 			cli, err := minio.New(endpoint, &minio.Options{
 				// GetBucketLocation will succeed as long as the bucket exists
 				Creds:        credentials.NewStaticV4(args.AK, args.SK, ""),
 				Secure:       args.UseSSL,
-				BucketLookup: minio.BucketLookupDNS,
+				BucketLookup: bucketLookup,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Issue: Milvus-Operator initialize the new Milvus cluster ended with failure while the configured external storage don't support virutal host mode, even if the config set the field `useVirtualHost` to false.

Fix: align the startup check condition with storage conf fields. User can set `useVirtualHost` to false while their storage don't support virtual host mode.