### PR TITLE
fixed secret name for cert volume

### DIFF
--- a/charts/milvus-operator/templates/deployment.yaml
+++ b/charts/milvus-operator/templates/deployment.yaml
@@ -68,5 +68,5 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          # secretName: {{ include "$.chart.fullname" . }}-webhook-cert
+          secretName: {{ include "chart.fullname" . }}-webhook-cert
       {{- end }}

--- a/charts/milvus-operator/templates/deployment.yaml
+++ b/charts/milvus-operator/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --leader-elect
-        {{- if not .Values.enableWebhook }}
-        - --webhook=false
+        {{- if .Values.enableWebhook }}
+        - --webhook=true
         {{- end }}
         command:
         - /manager


### PR DESCRIPTION
This PR adds the secretName to the cert volume. Without this, the deployment does not work.