### PR TITLE
Standardize kind action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
           key: ubuntu${{ matrix.ubuntu }}-testbin
           restore-keys: ubuntu${{ matrix.ubuntu }}-testbin
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e # v2.0.4
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind
       - name: Unit Test
         run: |
           make go-generate
@@ -105,9 +107,9 @@ jobs:
         run: |
           make sit-prepare-images
       - name: Setup KinD Cluster
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Deploy to KinD
         run: |
           make sit-deploy
@@ -139,9 +141,9 @@ jobs:
         run: |
           make sit-prepare-images
       - name: Setup KinD Cluster
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Deploy to KinD
         run: |
           make sit-deploy
@@ -166,10 +168,9 @@ jobs:
         run: |
           make sit-prepare-images
       - name: Setup KinD Cluster
-        uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e # v2.0.4
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.18.0"
-          kubectl_version: "v1.24.0"
+          cluster_name: kind
       - name: Deploy to KinD
         run: |
           make sit-deploy
@@ -194,9 +195,9 @@ jobs:
         run: |
           make sit-prepare-images
       - name: Setup KinD Cluster
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Deploy to KinD
         run: |
           make sit-deploy
@@ -218,9 +219,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup KinD Cluster
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Prepare Docker Images
         run: |
           make sit-prepare-images

--- a/.github/workflows/deploy-manifest.yaml
+++ b/.github/workflows/deploy-manifest.yaml
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup KinD Cluster
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Deploy by manifest
         run: |
           make deploy-by-manifest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           make sit-prepare-images
       - name: Setup KinD Cluster
-        engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.11.1"
+          cluster_name: kind
       - name: Deploy to KinD
         run: |
           make sit-deploy

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,10 @@ deploy-manifests: manifests kustomize helm-generate
 	helm template milvus-operator --create-namespace -n milvus-operator ./charts/milvus-operator-$(VERSION).tgz  >> deploy/manifests/deployment.yaml
 
 kind-dev: kind
-	sudo $(KIND) create cluster --config config/kind/kind-dev.yaml --name ${KIND_CLUSTER}
+	sudo $(KIND) create cluster --config config/kind/kind-dev.yaml --name $(KIND_CLUSTER)
 
 uninstall-kind-dev: kind
-	sudo $(KIND) delete cluster --name ${KIND_CLUSTER}
+	sudo $(KIND) delete cluster --name $(KIND_CLUSTER)
 
 # Install local certificate
 # Required for webhook server to start
@@ -244,19 +244,19 @@ sit-prepare-images: sit-prepare-operator-images
 
 sit-load-operator-images:
 	@echo "Loading operator images"
-	kind load docker-image ${SIT_IMG} --name ${KIND_CLUSTER}
-	kind load docker-image quay.io/jetstack/cert-manager-controller:v1.5.3 --name ${KIND_CLUSTER}
-	kind load docker-image quay.io/jetstack/cert-manager-webhook:v1.5.3 --name ${KIND_CLUSTER}
-	kind load docker-image quay.io/jetstack/cert-manager-cainjector:v1.5.3 --name ${KIND_CLUSTER}
+	kind load docker-image ${SIT_IMG} --name $(KIND_CLUSTER)
+	kind load docker-image quay.io/jetstack/cert-manager-controller:v1.5.3 --name $(KIND_CLUSTER)
+	kind load docker-image quay.io/jetstack/cert-manager-webhook:v1.5.3 --name $(KIND_CLUSTER)
+	kind load docker-image quay.io/jetstack/cert-manager-cainjector:v1.5.3 --name $(KIND_CLUSTER)
 
 sit-load-images: sit-load-operator-images
 	@echo "Loading images"
 	kind load docker-image milvusdb/milvus:v2.5.4
-	# kind load docker-image apachepulsar/pulsar:2.8.2 --name ${KIND_CLUSTER}
-	kind load docker-image bitnami/kafka:3.1.0-debian-10-r52 --name ${KIND_CLUSTER}
-	kind load docker-image milvusdb/etcd:3.5.14-r1 --name ${KIND_CLUSTER}
-	kind load docker-image minio/minio:RELEASE.2023-03-20T20-16-18Z --name ${KIND_CLUSTER}
-	kind load docker-image bitnami/pymilvus:2.4.6 --name ${KIND_CLUSTER}
+	# kind load docker-image apachepulsar/pulsar:2.8.2 --name $(KIND_CLUSTER)
+	kind load docker-image bitnami/kafka:3.1.0-debian-10-r52 --name $(KIND_CLUSTER)
+	kind load docker-image milvusdb/etcd:3.5.14-r1 --name $(KIND_CLUSTER)
+	kind load docker-image minio/minio:RELEASE.2023-03-20T20-16-18Z --name $(KIND_CLUSTER)
+	kind load docker-image bitnami/pymilvus:2.4.6 --name $(KIND_CLUSTER)
 
 sit-load-and-cleanup-images: sit-load-images
 	@echo "Clean up some big images to save disk space in github action"


### PR DESCRIPTION
Standardize on `helm/kind-action` for consistency across various CI workflows.
* Cleanup old version pinning for kind/kubectl.