### PR TITLE
Fix token renewal

### DIFF
--- a/pkg/controllers/dependencies_test.go
+++ b/pkg/controllers/dependencies_test.go
@@ -23,9 +23,15 @@ func TestLocalHelmReconciler_ReconcilePanic(t *testing.T) {
 	settings := cli.New()
 	logger := ctrl.Log.WithName("test")
 
+	// Create a mock manager
+	mockManager := NewMockManager(mockCtrl)
+
+	// Setup expectations for the manager
+	mockManager.EXPECT().GetConfig().Return(nil).AnyTimes()
+
 	ctx := context.TODO()
 	request := helm.ChartRequest{}
-	rec := MustNewLocalHelmReconciler(settings, logger)
+	rec := MustNewLocalHelmReconciler(settings, logger, mockManager)
 
 	// bad driver failed
 	os.Setenv("HELM_DRIVER", "bad")
@@ -49,9 +55,15 @@ func TestLocalHelmReconciler_Reconcile(t *testing.T) {
 	settings := cli.New()
 	logger := ctrl.Log.WithName("test")
 
+	// Create a mock manager
+	mockManager := NewMockManager(mockCtrl)
+
+	// Setup expectations for the manager
+	mockManager.EXPECT().GetConfig().Return(nil).AnyTimes()
+
 	ctx := context.TODO()
 	request := helm.ChartRequest{}
-	rec := MustNewLocalHelmReconciler(settings, logger)
+	rec := MustNewLocalHelmReconciler(settings, logger, mockManager)
 	errTest := errors.New("test")
 
 	t.Run("ReleaseExist failed", func(t *testing.T) {

--- a/pkg/controllers/manager_interface.go
+++ b/pkg/controllers/manager_interface.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+//go:generate mockgen -package=controllers -source=manager_interface.go -destination=manager_mock.go Manager
+
+// Manager defines the interface for a controller-runtime manager
+type Manager interface {
+	// Add adds a runnable to the Manager
+	Add(manager.Runnable) error
+
+	// AddHealthzCheck allows you to add a HealthzCheck to the Manager
+	AddHealthzCheck(name string, check healthz.Checker) error
+
+	// AddReadyzCheck allows you to add a ReadyzCheck to the Manager
+	AddReadyzCheck(name string, check healthz.Checker) error
+
+	// AddMetricsServerExtraHandler adds an extra handler to the Metrics server
+	AddMetricsServerExtraHandler(path string, handler http.Handler) error
+
+	// Start starts the Manager and waits for it to be stopped
+	Start(ctx context.Context) error
+
+	// GetConfig returns the rest.Config used by the Manager
+	GetConfig() *rest.Config
+
+	// GetScheme returns the scheme.Scheme used by the Manager
+	GetScheme() *runtime.Scheme
+
+	// GetClient returns the client.Client used by the Manager
+	GetClient() client.Client
+
+	// GetFieldIndexer returns the client.FieldIndexer used by the Manager
+	GetFieldIndexer() client.FieldIndexer
+
+	// GetCache returns the cache.Cache used by the Manager
+	GetCache() cache.Cache
+
+	// GetEventRecorderFor returns a new record.EventRecorder for the provided name
+	GetEventRecorderFor(name string) record.EventRecorder
+
+	// GetRESTMapper returns the meta.RESTMapper used by the Manager
+	GetRESTMapper() meta.RESTMapper
+
+	// GetAPIReader returns a client.Reader that will hit the API server
+	GetAPIReader() client.Reader
+
+	// GetWebhookServer returns the webhook server used by the Manager
+	GetWebhookServer() webhook.Server
+
+	// GetLogger returns the logger used by the Manager
+	GetLogger() logr.Logger
+
+	// GetControllerOptions returns the controller options
+	GetControllerOptions() config.Controller
+
+	// Elected returns a channel that is closed when this Manager is elected leader
+	Elected() <-chan struct{}
+
+	// GetHTTPClient returns the http.Client used by the Manager
+	GetHTTPClient() *http.Client
+}

--- a/pkg/controllers/setup.go
+++ b/pkg/controllers/setup.go
@@ -9,7 +9,6 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,15 +40,9 @@ func SetupControllers(ctx context.Context, mgr manager.Manager, stopReconcilers 
 	logger := ctrl.Log.WithName("controller")
 
 	if len(stopReconcilers) == 0 || stopReconcilers[0] != "all" {
-		conf := mgr.GetConfig()
 		settings := cli.New()
-		settings.KubeAPIServer = conf.Host
 		settings.MaxHistory = 2
-		settings.KubeToken = conf.BearerToken
-		getter := settings.RESTClientGetter()
-		config := getter.(*genericclioptions.ConfigFlags)
-		config.Insecure = &configFlagInsecure
-		helmReconciler := MustNewLocalHelmReconciler(settings, logger.WithName("helm"))
+		helmReconciler := MustNewLocalHelmReconciler(settings, logger.WithName("helm"), mgr)
 
 		// should be run after mgr started to make sure the client is ready
 		statusSyncer := NewMilvusStatusSyncer(ctx, mgr.GetClient(), logger.WithName("status-syncer"))


### PR DESCRIPTION
Fix token renewal by using the runtime controller in the helm reconciler.

The previous code was copying the token to the helm reconciler, which would continue to use that token even after the service account token would be renewed.

Take a look at disk.NewCachedDiscoveryClientForConfig(...), not sure if that needs a different set of parameters.

Fixes https://github.com/zilliztech/milvus-operator/issues/257