### PR TITLE
Enable etcd monitoring

### DIFF
--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -163,7 +163,7 @@ type MilvusComponents struct {
 	// +kubebuilder:validation:Optional
 	DisableMetric bool `json:"disableMetric"`
 
-	// MetricInterval the interval of podmonitor metric scraping in string
+	// MetricInterval the interval of PodMonitor metric scraping in string
 	// +kubebuilder:validation:Optional
 	MetricInterval monitoringv1.Duration `json:"metricInterval"`
 

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -17,8 +17,9 @@ import (
 
 // const name or ports
 const (
-	MetricPortName = "metrics"
-	MetricPath     = "/metrics"
+	EtcdMetricPortName = "client"
+	MetricPortName     = "metrics"
+	MetricPath         = "/metrics"
 
 	RestfulPortName = "restful"
 


### PR DESCRIPTION
When internal etcd is in use, add the `client` port to the `PodMonitor` to collect metrics from the service pods.

Fixes: https://github.com/zilliztech/milvus-operator/issues/310