### PR TITLE
Consolidate semver libraries

### DIFF
--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -20,15 +20,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/zilliztech/milvus-operator/pkg/util"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -114,13 +112,13 @@ func (ms MilvusSpec) GetServiceComponent() *ServiceComponent {
 }
 
 // GetMilvusVersionByImage returns the version of Milvus by ms.Com.ComponentSpec.Image
-func (ms MilvusSpec) GetMilvusVersionByImage() (*semver.Version, error) {
+func (ms MilvusSpec) GetMilvusVersionByImage() (semver.Version, error) {
 	// parse format: registry/namespace/image:tag
 	splited := strings.Split(ms.Com.ComponentSpec.Image, ":")
 	if len(splited) != 2 {
-		return nil, errors.Errorf("unknown version of image[%s]", splited[0])
+		return semver.Version{}, errors.Errorf("unknown version of image[%s]", splited[0])
 	}
-	return util.GetSemanticVersion(splited[1])
+	return semver.ParseTolerant(splited[1])
 }
 
 func (ms *MilvusSpec) GetPersistenceConfig() *Persistence {

--- a/apis/milvus.io/v1beta1/milvus_types_test.go
+++ b/apis/milvus.io/v1beta1/milvus_types_test.go
@@ -209,10 +209,10 @@ func TestGetMilvusVersionByGlobalImage(t *testing.T) {
 	m.Spec.Com.ComponentSpec.Image = "milvusdb/milvus:v2.3.1-beta1"
 	ver, err := m.Spec.GetMilvusVersionByImage()
 	assert.NoError(t, err)
-	assert.Equal(t, int64(2), ver.Major)
-	assert.Equal(t, int64(3), ver.Minor)
-	assert.Equal(t, int64(1), ver.Patch)
-	assert.Equal(t, "beta1", ver.PreRelease.Slice()[0])
+	assert.Equal(t, uint64(2), ver.Major)
+	assert.Equal(t, uint64(3), ver.Minor)
+	assert.Equal(t, uint64(1), ver.Patch)
+	assert.Equal(t, "beta1", ver.Pre[0].VersionStr)
 
 	m.Spec.Com.ComponentSpec.Image = "harbor.milvus.io/milvus/milvus:latest"
 	_, err = m.Spec.GetMilvusVersionByImage()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/aliyun/credentials-go v1.4.3
 	github.com/apache/pulsar-client-go v0.9.0
-	github.com/coreos/go-semver v0.3.1
+	github.com/blang/semver/v4 v4.0.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-logr/logr v1.4.2
 	github.com/minio/madmin-go v1.7.5
@@ -28,7 +28,6 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.14
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.26.0
-	golang.org/x/mod v0.23.0
 	golang.org/x/oauth2 v0.27.0
 	google.golang.org/api v0.219.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -70,13 +69,13 @@ require (
 	github.com/ardielle/ardielle-go v1.5.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.3.4 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
@@ -208,6 +207,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
+	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,17 +14,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig"
-	"github.com/coreos/go-semver/semver"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const MqTypeConfigKey = "messageQueue"
-
-func GetSemanticVersion(version string) (*semver.Version, error) {
-	return semver.NewVersion(strings.TrimPrefix(version, "v"))
-}
 
 // GetNumberValue supports int64 / float64 in values return as float64
 // see https://datatracker.ietf.org/doc/html/rfc8259#section-6


### PR DESCRIPTION
Switch semver library use to `github.com/blang/semver/v4` to be consistent across various uses. This is the semver library used by `sigs.k8s.io/controller-runtime`, so it's consistent and reduces the number of dependencies.

This also simplifies and eliminates cross dependencies between the API packages and the operator runtime.