### PR TITLE
Support applying custom metric labels before ingestion

### DIFF
--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -167,6 +167,10 @@ type MilvusComponents struct {
 	// +kubebuilder:validation:Optional
 	MetricInterval monitoringv1.Duration `json:"metricInterval"`
 
+	// MetricLabels labels to be assigned to samples before ingestion
+	// +kubebuilder:validation:Optional
+	MetricLabels map[string]string `json:"metricLabels,omitempty"`
+
 	// ToolImage specify tool image to merge milvus config to original one in image, default uses same image as milvus-operator
 	// +kubebuilder:validation:Optional
 	ToolImage string `json:"toolImage,omitempty"`

--- a/apis/milvus.io/v1beta1/zz_generated.deepcopy.go
+++ b/apis/milvus.io/v1beta1/zz_generated.deepcopy.go
@@ -240,6 +240,13 @@ func (in *MilvusComponents) DeepCopyInto(out *MilvusComponents) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MetricLabels != nil {
+		in, out := &in.MetricLabels, &out.MetricLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Proxy != nil {
 		in, out := &in.Proxy, &out.Proxy
 		*out = new(MilvusProxy)

--- a/charts/milvus-operator/templates/crds.yaml
+++ b/charts/milvus-operator/templates/crds.yaml
@@ -3160,6 +3160,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:
@@ -12425,6 +12429,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:

--- a/config/crd/bases/milvus.io_milvusclusters.yaml
+++ b/config/crd/bases/milvus.io_milvusclusters.yaml
@@ -3158,6 +3158,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -4206,6 +4206,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:

--- a/config/samples/milvus_metric_labels.yaml
+++ b/config/samples/milvus_metric_labels.yaml
@@ -1,0 +1,23 @@
+# This is a sample to deploy a milvus with metrics labels.
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  components:
+    metricLabels:
+      test_label1: test_value1
+      test_label2: test_value2
+  dependencies:
+    etcd:
+      inCluster:
+        values:
+          replicaCount: 1
+    storage:
+      inCluster:
+        values:
+          mode: standalone
+          resources:
+            requests:

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -3178,6 +3178,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:
@@ -12444,6 +12448,10 @@ spec:
                   metricInterval:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   mixCoord:
                     properties:
                       affinity:


### PR DESCRIPTION
- Introduced the `metricLabels` configuration, supporting applying custom metric labels prior to ingestion. Under the hood, this utilizes Prometheus `metric_relabel_configs` to append the new labels.

- Added `milvus_metric_labels.yaml` for deploying Milvus instances with metric labels applied.