### PR TITLE
feat: change targetPort to int.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@latest)
 
 KIND = $(shell pwd)/bin/kind
 kind: ## Download kind locally if necessary.

--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -148,6 +148,11 @@ const (
 type MilvusComponents struct {
 	ComponentSpec `json:",inline"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:={"string", "integer"}
+	// +kubebuilder:default:="string"
+	TargetPortType ServiceTargetPortType `json:"targetPortType,omitempty"`
+
 	// ImageUpdateMode is how the milvus components' image should be updated. works only when rolling update is enabled.
 	// forceUpgrade will update all pods' image immediately, and kills the terminated pods to speed up the process
 	// +kubebuilder:validation:Enum=rollingUpgrade;rollingDowngrade;all;force

--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -43,6 +43,11 @@ type MilvusSpec struct {
 	Mode MilvusMode `json:"mode,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:={"string", "integer"}
+	// +kubebuilder:default:="string"
+	TargetPortType ServiceTargetPortType `json:"targetPortType,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	Com MilvusComponents `json:"components,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -145,6 +150,13 @@ type MilvusMode string
 const (
 	MilvusModeCluster    MilvusMode = "cluster"
 	MilvusModeStandalone MilvusMode = "standalone"
+)
+
+type ServiceTargetPortType string
+
+const (
+	ServiceTargetPortTypeString ServiceTargetPortType = "string"
+	ServiceTargetPortTypInteger ServiceTargetPortType = "integer"
 )
 
 // MilvusStatus defines the observed state of Milvus

--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -43,11 +43,6 @@ type MilvusSpec struct {
 	Mode MilvusMode `json:"mode,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:={"string", "integer"}
-	// +kubebuilder:default:="string"
-	TargetPortType ServiceTargetPortType `json:"targetPortType,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	Com MilvusComponents `json:"components,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/charts/milvus-operator/templates/crds.yaml
+++ b/charts/milvus-operator/templates/crds.yaml
@@ -7834,6 +7834,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:
@@ -17103,6 +17109,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:

--- a/config/crd/bases/milvus.io_milvusclusters.yaml
+++ b/config/crd/bases/milvus.io_milvusclusters.yaml
@@ -7832,6 +7832,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -9127,6 +9127,12 @@ spec:
                 - cluster
                 - standalone
                 type: string
+              targetPortType:
+                default: string
+                enum:
+                - string
+                - integer
+                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -8880,6 +8880,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:
@@ -9126,12 +9132,6 @@ spec:
                 enum:
                 - cluster
                 - standalone
-                type: string
-              targetPortType:
-                default: string
-                enum:
-                - string
-                - integer
                 type: string
             type: object
           status:

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -7852,6 +7852,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:
@@ -17122,6 +17128,12 @@ spec:
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
+                  targetPortType:
+                    default: string
+                    enum:
+                    - string
+                    - integer
+                    type: string
                   tolerations:
                     items:
                       properties:

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -261,7 +261,7 @@ func (c MilvusComponent) GetServiceType(spec v1beta1.MilvusSpec) corev1.ServiceT
 func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.ServicePort {
 	servicePorts := []corev1.ServicePort{}
 	targetPort := intstr.FromString(c.GetPortName())
-	if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+	if spec.Com.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
 		targetPort = intstr.FromInt32(c.GetComponentPort(spec))
 	}
 
@@ -273,7 +273,7 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 	})
 
 	targetPort = intstr.FromString(MetricPortName)
-	if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+	if spec.Com.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
 		targetPort = intstr.FromInt32(MetricPort)
 	}
 	servicePorts = append(servicePorts, corev1.ServicePort{
@@ -289,7 +289,7 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 			if len(port.Name) > 0 {
 				targetPort = intstr.FromString(port.Name)
 			}
-			if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+			if spec.Com.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
 				targetPort = intstr.FromInt32(port.ContainerPort)
 			}
 			servicePort := corev1.ServicePort{
@@ -305,7 +305,7 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 	restfulPort := c.GetRestfulPort(spec)
 	if restfulPort != 0 {
 		targetPort = intstr.FromString(RestfulPortName)
-		if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+		if spec.Com.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
 			targetPort = intstr.FromInt32(restfulPort)
 		}
 		servicePorts = append(servicePorts, corev1.ServicePort{

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -264,25 +264,23 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 		Name:       c.GetPortName(),
 		Protocol:   corev1.ProtocolTCP,
 		Port:       c.GetComponentPort(spec),
-		TargetPort: intstr.FromString(c.GetPortName()),
+		TargetPort: intstr.FromInt32(c.GetComponentPort(spec)),
 	})
 	servicePorts = append(servicePorts, corev1.ServicePort{
 		Name:       MetricPortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       MetricPort,
-		TargetPort: intstr.FromString(MetricPortName),
+		TargetPort: intstr.FromInt32(MetricPort),
 	})
 
 	sideCars := c.GetSideCars(spec)
 	for _, sideCar := range sideCars {
 		for _, port := range sideCar.Ports {
 			servicePort := corev1.ServicePort{
-				Name:     port.Name,
-				Protocol: port.Protocol,
-				Port:     port.ContainerPort,
-			}
-			if len(port.Name) > 0 {
-				servicePort.TargetPort = intstr.FromString(port.Name)
+				Name:       port.Name,
+				Protocol:   port.Protocol,
+				Port:       port.ContainerPort,
+				TargetPort: intstr.FromInt32(port.ContainerPort),
 			}
 			servicePorts = append(servicePorts, servicePort)
 		}
@@ -294,7 +292,7 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 			Name:       RestfulPortName,
 			Protocol:   corev1.ProtocolTCP,
 			Port:       restfulPort,
-			TargetPort: intstr.FromString(RestfulPortName),
+			TargetPort: intstr.FromInt32(restfulPort),
 		})
 	}
 

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -260,27 +260,43 @@ func (c MilvusComponent) GetServiceType(spec v1beta1.MilvusSpec) corev1.ServiceT
 // GetServicePorts returns the ports of the component service
 func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.ServicePort {
 	servicePorts := []corev1.ServicePort{}
+	targetPort := intstr.FromString(c.GetPortName())
+	if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+		targetPort = intstr.FromInt32(c.GetComponentPort(spec))
+	}
+
 	servicePorts = append(servicePorts, corev1.ServicePort{
 		Name:       c.GetPortName(),
 		Protocol:   corev1.ProtocolTCP,
 		Port:       c.GetComponentPort(spec),
-		TargetPort: intstr.FromInt32(c.GetComponentPort(spec)),
+		TargetPort: targetPort,
 	})
+
+	targetPort = intstr.FromString(MetricPortName)
+	if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+		targetPort = intstr.FromInt32(MetricPort)
+	}
 	servicePorts = append(servicePorts, corev1.ServicePort{
 		Name:       MetricPortName,
 		Protocol:   corev1.ProtocolTCP,
 		Port:       MetricPort,
-		TargetPort: intstr.FromInt32(MetricPort),
+		TargetPort: targetPort,
 	})
 
 	sideCars := c.GetSideCars(spec)
 	for _, sideCar := range sideCars {
 		for _, port := range sideCar.Ports {
+			if len(port.Name) > 0 {
+				targetPort = intstr.FromString(port.Name)
+			}
+			if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+				targetPort = intstr.FromInt32(port.ContainerPort)
+			}
 			servicePort := corev1.ServicePort{
 				Name:       port.Name,
 				Protocol:   port.Protocol,
 				Port:       port.ContainerPort,
-				TargetPort: intstr.FromInt32(port.ContainerPort),
+				TargetPort: targetPort,
 			}
 			servicePorts = append(servicePorts, servicePort)
 		}
@@ -288,11 +304,15 @@ func (c MilvusComponent) GetServicePorts(spec v1beta1.MilvusSpec) []corev1.Servi
 
 	restfulPort := c.GetRestfulPort(spec)
 	if restfulPort != 0 {
+		targetPort = intstr.FromString(RestfulPortName)
+		if spec.TargetPortType == v1beta1.ServiceTargetPortTypInteger {
+			targetPort = intstr.FromInt32(restfulPort)
+		}
 		servicePorts = append(servicePorts, corev1.ServicePort{
 			Name:       RestfulPortName,
 			Protocol:   corev1.ProtocolTCP,
 			Port:       restfulPort,
-			TargetPort: intstr.FromInt32(restfulPort),
+			TargetPort: targetPort,
 		})
 	}
 


### PR DESCRIPTION
Some loadBalancer component dont support targetPort is string type on the cloud. Normally it should be of type int
