### PR TITLE
Milvus26 upgrade

### DIFF
--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -58,6 +58,11 @@ type ComponentSpec struct {
 	// +kubebuilder:validation:Optional
 	Image string `json:"image,omitempty"`
 
+	// Version specifies the version of the image, users can specify their desired version
+	// The tag of image will be used if not specified
+	// +kubebuilder:validation:Optional
+	Version string `json:"version,omitempty"`
+
 	// Commands override the default commands & args of the container
 	// +kubebuilder:validation:Optional
 	Commands []string `json:"commands,omitempty"`

--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -117,28 +117,28 @@ func (ms MilvusSpec) IsVersionGreaterThan2_6() bool {
 
 func isImageVersionGreaterThan2_6(version, image string) bool {
 	if version != "" {
-		sematicVersion, err := semver.ParseTolerant(version)
+		semanticVersion, err := semver.ParseTolerant(version)
 		if err != nil {
 			return false
 		}
-		return sematicVersion.GT(sermaticVersion2_5_Max)
+		return semanticVersion.GT(sermanticVersion2_5_Max)
 	}
 
 	// use tag if version is not set, parse format: registry/namespace/image:tag
-	splited := strings.Split(image, ":")
+	parts := strings.Split(image, ":")
 
-	if len(splited) != 2 {
+	if len(parts) != 2 {
 		return false
 	}
-	imageTag := splited[1]
+	imageTag := parts[1]
 	if strings.HasPrefix(imageTag, "master-") {
 		return true
 	}
-	sematicVersion, err := semver.ParseTolerant(imageTag)
+	semanticVersion, err := semver.ParseTolerant(imageTag)
 	if err != nil {
 		return false
 	}
-	return sematicVersion.GT(sermaticVersion2_5_Max)
+	return semanticVersion.GT(sermanticVersion2_5_Max)
 }
 
 // GetMilvusVersionByImage returns the version of Milvus by ms.Com.ComponentSpec.Image
@@ -168,7 +168,7 @@ func (ms *MilvusSpec) UseMixCoord() bool {
 	return ms.Com.MixCoord != nil
 }
 
-var sermaticVersion2_5_Max = semver.MustParse("2.5.999")
+var sermanticVersion2_5_Max = semver.MustParse("2.5.999")
 
 func (ms *MilvusSpec) UseStreamingNode() bool {
 	if ms.IsVersionGreaterThan2_6() {

--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -112,8 +112,21 @@ func (ms MilvusSpec) GetServiceComponent() *ServiceComponent {
 }
 
 func (ms MilvusSpec) IsVersionGreaterThan2_6() bool {
-	// parse format: registry/namespace/image:tag
-	splited := strings.Split(ms.Com.Image, ":")
+	return isImageVersionGreaterThan2_6(ms.Com.Version, ms.Com.Image)
+}
+
+func isImageVersionGreaterThan2_6(version, image string) bool {
+	if version != "" {
+		sematicVersion, err := semver.ParseTolerant(version)
+		if err != nil {
+			return false
+		}
+		return sematicVersion.GT(sermaticVersion2_5_Max)
+	}
+
+	// use tag if version is not set, parse format: registry/namespace/image:tag
+	splited := strings.Split(image, ":")
+
 	if len(splited) != 2 {
 		return false
 	}
@@ -158,13 +171,17 @@ func (ms *MilvusSpec) UseMixCoord() bool {
 var sermaticVersion2_5_Max = semver.MustParse("2.5.999")
 
 func (ms *MilvusSpec) UseStreamingNode() bool {
+	if ms.IsVersionGreaterThan2_6() {
+		return true
+	}
+
 	if ms.Com.StreamingMode != nil {
 		return *ms.Com.StreamingMode
 	}
 	if ms.Com.StreamingNode != nil {
 		return true
 	}
-	return ms.IsVersionGreaterThan2_6()
+	return false
 }
 
 // MilvusMode defines the mode of Milvus deployment
@@ -209,6 +226,14 @@ type MilvusStatus struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
+
+	// CurrentImage is the current image of the milvus cluster
+	// +optional
+	CurrentImage string `json:"currentImage,omitempty"`
+
+	// CurrentVersion is the current version of the milvus cluster
+	// +optional
+	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
 // RollingMode we have changed our rolling mode several times, so we use this enum to track the version of rolling mode the milvus CR is using
@@ -467,6 +492,10 @@ type Milvus struct {
 
 	Spec   MilvusSpec   `json:"spec,omitempty"`
 	Status MilvusStatus `json:"status,omitempty"`
+}
+
+func (m *Milvus) IsCurrentImageVersionGreaterThan2_6() bool {
+	return isImageVersionGreaterThan2_6(m.Status.CurrentVersion, m.Status.CurrentImage)
 }
 
 func (m *Milvus) IsFirstTimeStarting() bool {

--- a/apis/milvus.io/v1beta1/milvus_types_test.go
+++ b/apis/milvus.io/v1beta1/milvus_types_test.go
@@ -245,9 +245,9 @@ func TestGetActiveConfigMap_SetActiveConfigMap(t *testing.T) {
 }
 
 func TestMilvus_setDefaultMsgStreamType(t *testing.T) {
-	mc := Milvus{}
 
 	t.Run("standalone with master image use wood pecker", func(t *testing.T) {
+		mc := Milvus{}
 		mc.Spec.Mode = MilvusModeStandalone
 		mc.Spec.Com.Image = "milvusdb/milvus:master-"
 		mc.setDefaultMsgStreamType()
@@ -255,22 +255,34 @@ func TestMilvus_setDefaultMsgStreamType(t *testing.T) {
 	})
 
 	t.Run("standalone with 2.6 image use wood pecker", func(t *testing.T) {
+		mc := Milvus{}
 		mc.Spec.Mode = MilvusModeStandalone
 		mc.Spec.Com.Image = "milvusdb/milvus:2.6.0-rc1"
 		mc.setDefaultMsgStreamType()
 		assert.Equal(t, MsgStreamTypeWoodPecker, mc.Spec.Dep.MsgStreamType)
 	})
 	t.Run("standalone with 2.5 image use rocksmq", func(t *testing.T) {
+		mc := Milvus{}
 		mc.Spec.Mode = MilvusModeStandalone
 		mc.Spec.Com.Image = "milvusdb/milvus:2.5.11"
 		mc.setDefaultMsgStreamType()
 		assert.Equal(t, MsgStreamTypeRocksMQ, mc.Spec.Dep.MsgStreamType)
 	})
 	t.Run("standalone with other image use rocksmq", func(t *testing.T) {
+		mc := Milvus{}
 		mc.Spec.Mode = MilvusModeStandalone
 		mc.Spec.Com.Image = "milvusdb/milvus:unknown"
 		mc.setDefaultMsgStreamType()
 		assert.Equal(t, MsgStreamTypeRocksMQ, mc.Spec.Dep.MsgStreamType)
+	})
+
+	t.Run("standalone with version specified 2.6 image use wood pecker", func(t *testing.T) {
+		mc := Milvus{}
+		mc.Spec.Mode = MilvusModeStandalone
+		mc.Spec.Com.Image = "milvusdb/milvus:dev-20250609-100000-g1234567"
+		mc.Spec.Com.Version = "2.6.0-rc1"
+		mc.setDefaultMsgStreamType()
+		assert.Equal(t, MsgStreamTypeWoodPecker, mc.Spec.Dep.MsgStreamType)
 	})
 
 }

--- a/apis/milvus.io/v1beta1/milvus_webhook.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook.go
@@ -281,7 +281,7 @@ func (r *Milvus) DefaultComponents() {
 		if spec.Com.DataNode == nil {
 			spec.Com.DataNode = &MilvusDataNode{}
 		}
-		if spec.Com.IndexNode == nil {
+		if !spec.IsVersionGreaterThan2_6() && spec.Com.IndexNode == nil {
 			spec.Com.IndexNode = &MilvusIndexNode{}
 		}
 		if spec.Com.QueryNode == nil {
@@ -345,9 +345,7 @@ func (r *Milvus) defaultComponentsReplicas() {
 			spec.Com.DataNode.Replicas = &defaultReplicas
 		}
 
-		if spec.IsVersionGreaterThan2_6() {
-			spec.Com.IndexNode.Replicas = &defaultNoReplicas
-		} else {
+		if !spec.IsVersionGreaterThan2_6() {
 			if spec.Com.IndexNode.Replicas == nil {
 				spec.Com.IndexNode.Replicas = &defaultReplicas
 			}

--- a/apis/milvus.io/v1beta1/milvus_webhook_test.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook_test.go
@@ -108,7 +108,8 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 		ComponentSpec: ComponentSpec{
 			Image: config.DefaultMilvusImage,
 		},
-		RollingMode: RollingModeV2,
+		StreamingMode: util.BoolPtr(false),
+		RollingMode:   RollingModeV2,
 		Proxy: &MilvusProxy{
 			ServiceComponent: ServiceComponent{
 				Component: defaultComponent,
@@ -138,6 +139,7 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 		mc := Milvus{ObjectMeta: metav1.ObjectMeta{Name: crName}}
 		mc.Spec.Mode = MilvusModeCluster
 		mc.Default()
+		assert.False(t, mc.Spec.IsVersionGreaterThan2_6())
 		assert.Equal(t, clusterDefault, mc.Spec)
 	})
 

--- a/config/crd/bases/milvus.io_milvusclusters.yaml
+++ b/config/crd/bases/milvus.io_milvusclusters.yaml
@@ -1093,6 +1093,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -1738,6 +1740,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -2482,6 +2486,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -3127,6 +3133,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -3779,6 +3787,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -4490,6 +4500,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -5135,6 +5147,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -5780,6 +5794,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -6460,6 +6476,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -7159,6 +7177,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -7807,6 +7827,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -7857,6 +7879,8 @@ spec:
                     type: boolean
                   updateToolImage:
                     type: boolean
+                  version:
+                    type: string
                   volumeMounts:
                     items:
                       properties:
@@ -8185,6 +8209,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentImage:
+                type: string
+              currentVersion:
+                type: string
               endpoint:
                 type: string
               ingress:

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -911,6 +911,8 @@ spec:
                       type: string
                   type: object
                 type: array
+              version:
+                type: string
               volumeMounts:
                 items:
                   properties:
@@ -1023,6 +1025,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentImage:
+                type: string
+              currentVersion:
+                type: string
               endpoint:
                 type: string
               ingress:
@@ -2169,6 +2175,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -2814,6 +2822,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -3558,6 +3568,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -4203,6 +4215,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -4855,6 +4869,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -5566,6 +5582,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -6211,6 +6229,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -6856,6 +6876,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -7536,6 +7558,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -8235,6 +8259,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -8883,6 +8909,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                      version:
+                        type: string
                       volumeMounts:
                         items:
                           properties:
@@ -8933,6 +8961,8 @@ spec:
                     type: boolean
                   updateToolImage:
                     type: boolean
+                  version:
+                    type: string
                   volumeMounts:
                     items:
                       properties:
@@ -9271,6 +9301,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentImage:
+                type: string
+              currentVersion:
+                type: string
               endpoint:
                 type: string
               ingress:

--- a/config/samples/beta/milvus_streaming_node.yaml
+++ b/config/samples/beta/milvus_streaming_node.yaml
@@ -10,9 +10,7 @@ metadata:
 spec:
   mode: 'cluster'
   components:
-    enableRollingUpdate: false # milvus 2.5.0-beta bug: not supported standby for streaming coord
-    image: milvusdb/milvus:v2.5.0-beta
-    streamingNode:
-      replicas: 1
+    enableRollingUpdate: false 
+    image: milvusdb/milvus:v2.5.11
   dependencies:
     msgStreamType: pulsar # for now only support pulsar

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -648,9 +648,3 @@ func MergeComponentSpec(src, dst ComponentSpec) ComponentSpec {
 
 	return dst
 }
-
-// IsUpgradingTo26 checks if this is a 2.5 to 2.6 upgrade scenario
-func (c MilvusComponent) IsUpgradingTo26(milvus *v1beta1.Milvus) bool {
-	return milvus.Spec.IsVersionGreaterThan2_6() &&
-		!milvus.IsCurrentImageVersionGreaterThan2_6()
-}

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -103,6 +103,10 @@ var (
 		RootCoord, DataCoord, QueryCoord, IndexCoord,
 	}
 
+	Milvus2_6Components = []MilvusComponent{
+		MixCoord, DataNode, StreamingNode, QueryNode, Proxy, MilvusStandalone,
+	}
+
 	// coordConfigFieldName is a map of coordinator's name to config field name
 	coordConfigFieldName = map[string]string{
 		RootCoordName:  "rootCoord",
@@ -127,6 +131,9 @@ func IsMilvusDeploymentsComplete(m *v1beta1.Milvus) bool {
 func GetComponentsBySpec(spec v1beta1.MilvusSpec) []MilvusComponent {
 	if spec.Mode != v1beta1.MilvusModeCluster {
 		return StandaloneComponents
+	}
+	if spec.IsVersionGreaterThan2_6() {
+		return Milvus2_6Components
 	}
 	var ret = []MilvusComponent{}
 	if spec.UseMixCoord() {

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -378,6 +378,13 @@ func (c MilvusComponent) GetComponentSpec(spec v1beta1.MilvusSpec) v1beta1.Compo
 	return comSpec
 }
 
+func (c MilvusComponent) GetDependenciesFor2_6Upgrade(spec v1beta1.MilvusSpec) []MilvusComponent {
+	if spec.Mode != v1beta1.MilvusModeCluster {
+		return []MilvusComponent{}
+	}
+	return upgrade26ClusterDependencyGraph.GetDependencies(c)
+}
+
 func (c MilvusComponent) GetDependencies(spec v1beta1.MilvusSpec) []MilvusComponent {
 	if spec.Mode != v1beta1.MilvusModeCluster {
 		return []MilvusComponent{}
@@ -640,4 +647,10 @@ func MergeComponentSpec(src, dst ComponentSpec) ComponentSpec {
 	}
 
 	return dst
+}
+
+// IsUpgradingTo26 checks if this is a 2.5 to 2.6 upgrade scenario
+func (c MilvusComponent) IsUpgradingTo26(milvus *v1beta1.Milvus) bool {
+	return milvus.Spec.IsVersionGreaterThan2_6() &&
+		!milvus.IsCurrentImageVersionGreaterThan2_6()
 }

--- a/pkg/controllers/components_test.go
+++ b/pkg/controllers/components_test.go
@@ -33,6 +33,8 @@ func TestGetComponentsBySpec(t *testing.T) {
 	assert.Equal(t, MilvusComponents, GetComponentsBySpec(spec))
 	spec.Com.MixCoord = &v1beta1.MilvusMixCoord{}
 	assert.Equal(t, MixtureComponents, GetComponentsBySpec(spec))
+	spec.Com.Image = "milvusdb/milvus:v2.6.0"
+	assert.Equal(t, Milvus2_6Components, GetComponentsBySpec(spec))
 }
 
 func TestMilvusComponent_IsCoord(t *testing.T) {

--- a/pkg/controllers/dependency_graph.go
+++ b/pkg/controllers/dependency_graph.go
@@ -60,9 +60,16 @@ func init() {
 	streamingNodeClusterDependencyGraph.AddDependency(QueryNode, []MilvusComponent{StreamingNode})
 	streamingNodeClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})
 	streamingNodeClusterDependencyGraph.AddDependency(Proxy, []MilvusComponent{DataNode})
+
+	upgrade26ClusterDependencyGraph.AddDependency(StreamingNode, []MilvusComponent{})
+	upgrade26ClusterDependencyGraph.AddDependency(MixCoord, []MilvusComponent{StreamingNode})
+	upgrade26ClusterDependencyGraph.AddDependency(QueryNode, []MilvusComponent{MixCoord})
+	upgrade26ClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})
+	upgrade26ClusterDependencyGraph.AddDependency(Proxy, []MilvusComponent{DataNode})
 }
 
 var (
 	clusterDependencyGraph, mixCoordClusterDependencyGraph = newDependencyGraphImpl(), newDependencyGraphImpl()
 	streamingNodeClusterDependencyGraph                    = newDependencyGraphImpl()
+	upgrade26ClusterDependencyGraph                        = newDependencyGraphImpl()
 )

--- a/pkg/controllers/dependency_graph.go
+++ b/pkg/controllers/dependency_graph.go
@@ -54,8 +54,7 @@ func init() {
 	mixCoordClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})
 	mixCoordClusterDependencyGraph.AddDependency(Proxy, []MilvusComponent{DataNode})
 
-	streamingNodeClusterDependencyGraph.AddDependency(IndexNode, []MilvusComponent{})
-	streamingNodeClusterDependencyGraph.AddDependency(MixCoord, []MilvusComponent{IndexNode})
+	streamingNodeClusterDependencyGraph.AddDependency(MixCoord, []MilvusComponent{})
 	streamingNodeClusterDependencyGraph.AddDependency(StreamingNode, []MilvusComponent{MixCoord})
 	streamingNodeClusterDependencyGraph.AddDependency(QueryNode, []MilvusComponent{StreamingNode})
 	streamingNodeClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})

--- a/pkg/controllers/deploy_ctrl_test.go
+++ b/pkg/controllers/deploy_ctrl_test.go
@@ -228,7 +228,6 @@ func TestDeployControllerBizImpl_IsUpdating(t *testing.T) {
 	bizImpl := NewDeployControllerBizImpl(QueryNode, mockUtil, mockModeChanger, mockCli)
 	mc := v1beta1.Milvus{}
 	mc.Default()
-	component := QueryNode
 	t.Run("annotation shows already starts changing, so not updating", func(t *testing.T) {
 		v1beta1.Labels().SetChangingMode(&mc, QueryNodeName, true)
 		ret, err := bizImpl.IsUpdating(ctx, mc)
@@ -272,30 +271,7 @@ func TestDeployControllerBizImpl_IsUpdating(t *testing.T) {
 		},
 	}
 
-	t.Run("get old deploy failed", func(t *testing.T) {
-		mockUtil.EXPECT().GetOldDeploy(ctx, mc, component).Return(nil, errMock)
-		_, err := bizImpl.IsUpdating(ctx, mc)
-		assert.Error(t, err)
-	})
-
-	t.Run("is new rollout, so updating", func(t *testing.T) {
-		deploy := appsv1.Deployment{}
-
-		mockUtil.EXPECT().GetOldDeploy(ctx, mc, component).Return(&deploy, nil)
-		mockUtil.EXPECT().RenderPodTemplateWithoutGroupID(mc, gomock.Any(), QueryNode, false).Return(nil)
-		mockUtil.EXPECT().IsNewRollout(ctx, &deploy, gomock.Any()).Return(true)
-		ret, err := bizImpl.IsUpdating(ctx, mc)
-
-		assert.NoError(t, err)
-		assert.True(t, ret)
-	})
-
 	t.Run("not updating", func(t *testing.T) {
-		deploy := appsv1.Deployment{}
-
-		mockUtil.EXPECT().GetOldDeploy(ctx, mc, component).Return(&deploy, nil)
-		mockUtil.EXPECT().RenderPodTemplateWithoutGroupID(mc, gomock.Any(), QueryNode, false).Return(nil)
-		mockUtil.EXPECT().IsNewRollout(ctx, &deploy, gomock.Any()).Return(false)
 		ret, err := bizImpl.IsUpdating(ctx, mc)
 
 		assert.NoError(t, err)

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -249,15 +249,6 @@ func updateMilvusContainer(template *corev1.PodTemplateSpec, updater deploymentU
 	container.Args = updater.GetArgs()
 	env := mergedComSpec.Env
 	env = append(env, GetStorageSecretRefEnv(updater.GetSecretRef())...)
-	// omit setting the streaming node environment variable that is required for the streaming node beta version
-	// if updater.GetMilvus().Spec.UseStreamingNode() {
-	// 	env = append(env,
-	// 		corev1.EnvVar{
-	// 			Name:  "MILVUS_STREAMING_SERVICE_ENABLED",
-	// 			Value: "1",
-	// 		},
-	// 	)
-	// }
 	container.Env = MergeEnvVar(container.Env, env)
 	metricPort := corev1.ContainerPort{
 		Name:          MetricPortName,

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -249,14 +249,15 @@ func updateMilvusContainer(template *corev1.PodTemplateSpec, updater deploymentU
 	container.Args = updater.GetArgs()
 	env := mergedComSpec.Env
 	env = append(env, GetStorageSecretRefEnv(updater.GetSecretRef())...)
-	if updater.GetMilvus().Spec.UseStreamingNode() {
-		env = append(env,
-			corev1.EnvVar{
-				Name:  "MILVUS_STREAMING_SERVICE_ENABLED",
-				Value: "1",
-			},
-		)
-	}
+	// omit setting the streaming node environment variable that is required for the streaming node beta version
+	// if updater.GetMilvus().Spec.UseStreamingNode() {
+	// 	env = append(env,
+	// 		corev1.EnvVar{
+	// 			Name:  "MILVUS_STREAMING_SERVICE_ENABLED",
+	// 			Value: "1",
+	// 		},
+	// 	)
+	// }
 	container.Env = MergeEnvVar(container.Env, env)
 	metricPort := corev1.ContainerPort{
 		Name:          MetricPortName,

--- a/pkg/controllers/deployment_updater_test.go
+++ b/pkg/controllers/deployment_updater_test.go
@@ -152,6 +152,8 @@ func TestMilvus_UpdateDeployment(t *testing.T) {
 
 	t.Run("persistence disabled", func(t *testing.T) {
 		inst := env.Inst.DeepCopy()
+		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypePulsar
+		inst.Spec.Dep.RocksMQ.Persistence.Enabled = false
 		updater := newMilvusDeploymentUpdater(*inst, env.Reconciler.Scheme, MilvusStandalone)
 		deployment := sampleDeployment.DeepCopy()
 		err := updateDeployment(deployment, updater)
@@ -299,6 +301,7 @@ func TestMilvus_UpdateDeployment(t *testing.T) {
 	})
 
 	t.Run("streamingnode set env", func(t *testing.T) {
+		t.Skip()
 		inst := env.Inst.DeepCopy()
 		inst.Spec.Com.StreamingNode = &v1beta1.MilvusStreamingNode{}
 		inst.Default()

--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -88,6 +88,38 @@ func (r *MilvusReconciler) updateDeployment(
 	return updateDeployment(deployment, updater)
 }
 
+func (r *MilvusReconciler) DeleteDeploymentsIfExists(ctx context.Context, mc v1beta1.Milvus, component MilvusComponent) error {
+	namespacedName := NamespacedName(mc.Namespace, component.GetDeploymentName(mc.Name))
+	deployment := &appsv1.Deployment{}
+
+	err := r.Get(ctx, namespacedName, deployment)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			r.logger.Info("Deployment not found, skip delete",
+				"component", component.Name,
+				"name", namespacedName.Name,
+				"namespace", namespacedName.Namespace)
+			return nil
+		}
+		return pkgerr.Wrapf(err, "get deployment %s/%s failed", namespacedName.Namespace, namespacedName.Name)
+	}
+
+	r.logger.Info("Deleting deployment",
+		"component", component.Name,
+		"deployment name", deployment.Name,
+		"namespace", deployment.Namespace)
+
+	if err := r.Delete(ctx, deployment); err != nil {
+		return pkgerr.Wrapf(err, "delete deployment %s/%s failed", deployment.Namespace, deployment.Name)
+	}
+
+	r.logger.Info("Successfully deleted deployment",
+		"component", component.Name,
+		"deployment name", deployment.Name,
+		"namespace", deployment.Namespace)
+	return nil
+}
+
 func (r *MilvusReconciler) ReconcileComponentDeployment(
 	ctx context.Context, mc v1beta1.Milvus, component MilvusComponent,
 ) error {
@@ -231,6 +263,33 @@ func (r *MilvusReconciler) ReconcileDeployments(ctx context.Context, mc v1beta1.
 		return fmt.Errorf("reconcile milvus deployments errs: %w", err)
 	}
 
+	err = r.cleanupIndexNodeIfNeeded(ctx, mc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cleanupIndexNodeIfNeeded is part of the upgrade process to remove IndexNode which is no longer needed in 2.6+
+func (r *MilvusReconciler) cleanupIndexNodeIfNeeded(ctx context.Context, mc v1beta1.Milvus) error {
+	// offline indexnode for version >= 2.6, when proxy component's image has been updated
+	if mc.Spec.IsVersionGreaterThan2_6() && Proxy.IsImageUpdated(&mc) && mc.Spec.Com.IndexNode != nil {
+		r.logger.Info("Offline index node", "namespace", mc.Namespace, "name", mc.Name)
+
+		err := r.DeleteDeploymentsIfExists(ctx, mc, IndexNode)
+		if err != nil {
+			return err
+		}
+
+		mc.Spec.Com.IndexNode = nil
+		err = r.Update(ctx, &mc)
+		if err != nil {
+			return err
+		}
+
+		r.logger.Info("Successfully cleanup index node", "namespace", mc.Namespace, "name", mc.Name)
+	}
 	return nil
 }
 

--- a/pkg/controllers/milvus.go
+++ b/pkg/controllers/milvus.go
@@ -23,12 +23,19 @@ func (r *MilvusReconciler) SetDefaultStatus(ctx context.Context, mc *v1beta1.Mil
 	if mc.Status.Status == "" {
 		mc.Status.Status = v1beta1.StatusPending
 		mc.Status.RollingMode = mc.Spec.Com.RollingMode
+		mc.Status.CurrentImage = mc.Spec.Com.Image
+		mc.Status.CurrentVersion = mc.Spec.Com.Version
 		// metrics
 		milvusStatusCollector.WithLabelValues(mc.Namespace, mc.Name).
 			Set(MilvusStatusToCode(mc.Status.Status, mc.GetAnnotations()[MaintainingAnnotation] == "true"))
 
 		err := r.Client.Status().Update(ctx, mc)
 		return errors.Wrapf(err, "set mc default status[%s/%s] failed", mc.Namespace, mc.Name)
+	} else if mc.Status.CurrentImage == "" {
+		mc.Status.CurrentImage = mc.Spec.Com.Image
+		mc.Status.CurrentVersion = mc.Spec.Com.Version
+		err := r.Client.Status().Update(ctx, mc)
+		return errors.Wrapf(err, "set mc current image and version[%s/%s] failed", mc.Namespace, mc.Name)
 	}
 	return nil
 }

--- a/pkg/controllers/milvus_test.go
+++ b/pkg/controllers/milvus_test.go
@@ -134,24 +134,38 @@ func TestCluster_SetDefaultStatus(t *testing.T) {
 	errTest := errors.New("test")
 
 	// no status, set default failed
-	m := env.Inst
-	mockClient.EXPECT().Status().Return(mockStatusCli)
-	mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errTest)
-	err := r.SetDefaultStatus(ctx, &m)
-	assert.Error(t, err)
+	t.Run("no status, set default failed", func(t *testing.T) {
+		m := env.Inst
+		mockClient.EXPECT().Status().Return(mockStatusCli).Times(1)
+		mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errTest)
+		err := r.SetDefaultStatus(ctx, &m)
+		assert.Error(t, err)
+	})
 
-	// no status, set default ok
-	m = env.Inst // ptr value changed, need reset
-	mockClient.EXPECT().Status().Return(mockStatusCli)
-	mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any())
-	err = r.SetDefaultStatus(ctx, &m)
-	assert.NoError(t, err)
+	t.Run("no status, set default ok", func(t *testing.T) {
+		m := env.Inst
+		mockClient.EXPECT().Status().Return(mockStatusCli)
+		mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any())
+		err := r.SetDefaultStatus(ctx, &m)
+		assert.NoError(t, err)
+	})
 
-	// has status, not set
-	m = env.Inst // ptr value changed, need reset
-	m.Status.Status = v1beta1.StatusPending
-	err = r.SetDefaultStatus(ctx, &m)
-	assert.NoError(t, err)
+	t.Run("has status, missing currentImage, set default ok", func(t *testing.T) {
+		m := env.Inst
+		m.Status.Status = v1beta1.StatusPending
+		mockClient.EXPECT().Status().Return(mockStatusCli).Times(1)
+		mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any())
+		err := r.SetDefaultStatus(ctx, &m)
+		assert.NoError(t, err)
+	})
+
+	t.Run("has status and current image, not set", func(t *testing.T) {
+		m := env.Inst
+		m.Status.Status = v1beta1.StatusPending
+		m.Status.CurrentImage = "milvusdb/milvus:2.6.0"
+		err := r.SetDefaultStatus(ctx, &m)
+		assert.NoError(t, err)
+	})
 }
 
 func TestCluster_ReconcileAll(t *testing.T) {

--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -288,6 +288,13 @@ func (r *MilvusStatusSyncer) UpdateStatusForNewGeneration(ctx context.Context, m
 		return errors.Wrap(err, "handle terminating pods failed")
 	}
 
+	// set current milvus version annotation based on Spec when milvus is ready and updated
+	if IsMilvusConditionTrueByType(mc.Status.Conditions, v1beta1.MilvusReady) &&
+		IsMilvusConditionTrueByType(mc.Status.Conditions, v1beta1.MilvusUpdated) {
+		mc.Status.CurrentImage = mc.Spec.Com.Image
+		mc.Status.CurrentVersion = mc.Spec.Com.Version
+	}
+
 	statusInfo := MilvusHealthStatusInfo{
 		LastState:  mc.Status.Status,
 		IsStopping: mc.Spec.IsStopping(),

--- a/pkg/controllers/status_cluster_test.go
+++ b/pkg/controllers/status_cluster_test.go
@@ -86,6 +86,7 @@ func TestMilvusStatusSyncer_GetDependencyCondition(t *testing.T) {
 	milvus.Spec.Dep.Etcd.Endpoints = []string{"etcd"}
 	milvus.Spec.Dep.Kafka.BrokerList = []string{"kafka"}
 	milvus.Spec.Dep.Pulsar.Endpoint = "pulsar"
+	milvus.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypePulsar
 	t.Run("GetMinioCondition", func(t *testing.T) {
 		defer ctrl.Finish()
 		mockCli.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test"))

--- a/test/min-mc-feature.yaml
+++ b/test/min-mc-feature.yaml
@@ -41,9 +41,9 @@ spec:
           scheme: HTTP
         periodSeconds: 10
         successThreshold: 1
-    image: milvusdb/milvus:v2.5.0-beta
+    image: milvusdb/milvus:v2.5.11
     rollingMode: 3
-    enableRollingUpdate: false # milvus 2.5.0-beta bug: not supported standby for streaming coord
+    enableRollingUpdate: false 
     runWithSubProcess: true
     runAsNonRoot: true
     dummyImage: 'my-registry/my-dummy-image'
@@ -52,8 +52,6 @@ spec:
         hosts: ['mc-sit.milvus.io']
       replicas: 1
     mixCoord:
-      replicas: 1
-    streamingNode:
       replicas: 1
     volumes:
       - emptyDir: {}
@@ -68,7 +66,7 @@ spec:
         pvcDeletion: true
         values:
           replicaCount: 1
-    msgStreamType: woodpecker
+    msgStreamType: pulsar
     pulsar:
       inCluster:
         chartVersion: pulsar-v3

--- a/test/min-mc-mixture.yaml
+++ b/test/min-mc-mixture.yaml
@@ -35,7 +35,7 @@ spec:
         pvcDeletion: true
         values:
           replicaCount: 1
-    msgStreamType: woodpecker
+    msgStreamType: kafka
     kafka:
       inCluster:
         deletionPolicy: Delete


### PR DESCRIPTION
### Description
This PR implements support for upgrading Milvus to version 2.6, including necessary architectural changes, component updates, and version management improvements.

### Changes
1. **Version Management**
   - Added spec `version`(to specify the version if it cannot be determined from the image tag), `currentImage` `currentVersion` to CRD schema for better version tracking
   - Implemented version inspection mechanism for desired and actual image versions

2. **Component Updates**
   - Removed streaming node beta version
   - Cleaned up indexnode for image versions higher than 2.6
   - Added specific components for spec image versions greater than 2.6
   
3. **Testing & Validation**
   - Fixed Milvus default status tests
   - Added and updated test cases for version management
   - Improved test coverage for upgrade scenarios

### Testing
- [x] Unit tests updated and passing
- [x] Integration tests for upgrade scenarios
- [x] Manual testing of upgrade process