### PR TITLE
Performing an idempotent delete operation on the built-in message queue PVC

### DIFF
--- a/pkg/controllers/milvus.go
+++ b/pkg/controllers/milvus.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -120,7 +121,7 @@ var Finalize = func(ctx context.Context, r *MilvusReconciler, mc v1beta1.Milvus)
 			pvc := &corev1.PersistentVolumeClaim{}
 			pvc.Namespace = mc.Namespace
 			pvc.Name = pvcName
-			if err := r.Delete(ctx, pvc); err != nil {
+			if err := r.Delete(ctx, pvc); err != nil && !kerrors.IsNotFound(err) {
 				return errors.Wrap(err, "delete data pvc failed")
 			} else {
 				r.logger.Info("pvc deleted", "name", pvc.Name, "namespace", pvc.Namespace)


### PR DESCRIPTION
This pull request introduces error handling improvements in the `Finalize` function within the `MilvusReconciler` and adds corresponding test cases to ensure robustness. The changes primarily focus on handling `NotFound` errors gracefully when deleting PersistentVolumeClaims (PVCs).

### Error handling improvements:

* [`pkg/controllers/milvus.go`](diffhunk://#diff-bebf0a3871a24c311db9d684ca10fd8ddfb817e1708baca9cb3cb5051da0a66fL123-R124): Updated the `Finalize` function to ignore `NotFound` errors when deleting PVCs, ensuring that the reconciliation process does not fail unnecessarily.
* [`pkg/controllers/milvus.go`](diffhunk://#diff-bebf0a3871a24c311db9d684ca10fd8ddfb817e1708baca9cb3cb5051da0a66fR9): Added the `kerrors` import for Kubernetes API error handling utilities.

### Test case additions:

* `pkg/controllers/milvus_test.go`: Added test cases to validate the updated error handling logic in the `Finalize` function:
  - A test to ensure `NotFound` errors during PVC deletion are ignored.
  - A test to verify that errors other than `NotFound` are correctly propagated.