### PR TITLE
fix: return a set of errors that occur while reconciling milvus deployments

### DIFF
--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -283,7 +283,7 @@ func (r *MilvusReconciler) ReconcileDeployments(ctx context.Context, mc v1beta1.
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("reconcile milvus deployments errs: %w", err)
+		return fmt.Errorf("reconcile milvus %s deployments errs: %w", mc.Name, errors.Join(errs...))
 	}
 
 	err = r.cleanupIndexNodeIfNeeded(ctx, mc)


### PR DESCRIPTION
This pull request updates error handling in the `ReconcileDeployments` method to provide more specific context about the Milvus deployment being reconciled.

Error handling improvement:

* [`pkg/controllers/deployments.go`](diffhunk://#diff-6779fae6cce3248745a7ba4c8086eb2784baf0bd2b849c6d4b2f262c08eaaae2L286-R286): Enhanced the error message in the `ReconcileDeployments` method to include the name of the Milvus deployment (`mc.Name`) and combined multiple errors using `errors.Join` for better clarity and debugging.