### PR TITLE
fix: return a set of errors that occur while reconciling milvus deployments

### DIFF
--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -283,7 +283,7 @@ func (r *MilvusReconciler) ReconcileDeployments(ctx context.Context, mc v1beta1.
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("reconcile milvus deployments errs: %w", err)
+		return fmt.Errorf("reconcile milvus deployments errs: %w, name: %s, namespace: %s", errors.Join(errs...), mc.Name, mc.Namespace)
 	}
 
 	err = r.cleanupIndexNodeIfNeeded(ctx, mc)


### PR DESCRIPTION
This pull request improves error handling and expands test coverage for the `ReconcileDeployments` function in the `MilvusReconciler`. The changes include enhancing error messages to provide more context and adding a new test case to validate the behavior when multiple component errors occur.

### Error Handling Improvements:
* Enhanced the error message in `ReconcileDeployments` to include the `name` and `namespace` of the `Milvus` instance, along with the joined errors from multiple components. 

### Test Coverage Enhancements:
* Added a new test, `TestClusterReconciler_ReconcileDeployments_Error`, to verify that errors from multiple components are correctly joined and that the enhanced error message includes all relevant details such as the instance name, namespace, and individual component errors. 