### PR TITLE
feat: Add Kafka credentials support via Kubernetes secrets

### DIFF
--- a/apis/milvus.io/v1beta1/dependencies_types.go
+++ b/apis/milvus.io/v1beta1/dependencies_types.go
@@ -193,6 +193,11 @@ type MilvusKafka struct {
 
 	// +kubebuilder:validation:Optional
 	BrokerList []string `json:"brokerList,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// SecretRef is the reference to the secret containing Kafka credentials
+	// Expected keys: username, password
+	SecretRef string `json:"secretRef,omitempty"`
 }
 
 // MilvusTei configuration

--- a/config/samples/milvus_kafka_external_secret.yaml
+++ b/config/samples/milvus_kafka_external_secret.yaml
@@ -1,0 +1,46 @@
+# Example configuration for Milvus with external Kafka using secret credentials
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: milvus-kafka-credentials
+  namespace: milvus-system
+type: Opaque
+data:
+  # Base64 encoded username and password
+  username: bWlsdnVzLXVzZXI=  # milvus-user
+  password: bWlsdnVzLXBhc3M=  # milvus-pass
+---
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-release
+  namespace: milvus-system
+  labels:
+    app: milvus
+spec:
+  mode: cluster
+  config:
+    kafka:
+      # Security configuration for Kafka
+      securityProtocol: SASL_PLAINTEXT
+      saslMechanisms: PLAIN
+      # Note: saslUsername and saslPassword will be automatically injected
+      # from the secret specified in dependencies.kafka.secretRef
+  dependencies:
+    msgStreamType: kafka
+    kafka:
+      external: true
+      # Reference to the secret containing Kafka credentials
+      secretRef: "milvus-kafka-credentials"
+      brokerList:
+        - "kafka-broker-1:9092"
+        - "kafka-broker-2:9092"
+        - "kafka-broker-3:9092"
+    storage:
+      type: MinIO
+      endpoint: "minio:9000"
+      secretRef: "milvus-storage-credentials"
+    etcd:
+      endpoints:
+        - "etcd:2379"

--- a/docs/kafka-credentials.md
+++ b/docs/kafka-credentials.md
@@ -1,0 +1,107 @@
+# Kafka Credentials Support
+
+This document describes how to use Kubernetes secrets to securely provide Kafka credentials for external Kafka deployments.
+
+## Overview
+
+The milvus-operator now supports reading Kafka credentials from Kubernetes secrets, similar to how MinIO credentials are handled. This improves security by avoiding hardcoded credentials in the Milvus configuration.
+
+## Usage
+
+### 1. Create a Secret
+
+Create a Kubernetes secret containing your Kafka credentials:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: milvus-kafka-credentials
+  namespace: milvus-system
+type: Opaque
+data:
+  username: <base64-encoded-username>
+  password: <base64-encoded-password>
+```
+
+Or use kubectl:
+
+```bash
+kubectl create secret generic milvus-kafka-credentials \
+    --namespace=milvus-system \
+    --from-literal=username=your-kafka-username \
+    --from-literal=password=your-kafka-password
+```
+
+### 2. Configure Milvus
+
+Reference the secret in your Milvus configuration:
+
+```yaml
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-milvus
+  namespace: milvus-system
+spec:
+  config:
+    kafka:
+      securityProtocol: SASL_PLAINTEXT
+      saslMechanisms: PLAIN
+      # saslUsername and saslPassword will be automatically injected
+  dependencies:
+    msgStreamType: kafka
+    kafka:
+      external: true
+      secretRef: "milvus-kafka-credentials"  # Reference to the secret
+      brokerList:
+        - "kafka-broker:9092"
+```
+
+### 3. How it Works
+
+When the operator processes the Milvus configuration:
+
+1. It checks if `dependencies.kafka.secretRef` is specified
+2. If present, it reads the secret from the same namespace
+3. It extracts the `username` and `password` keys from the secret
+4. It automatically injects these values into the configuration as `kafka.saslUsername` and `kafka.saslPassword`
+
+## Secret Format
+
+The secret must contain the following keys:
+
+- `username`: The Kafka SASL username
+- `password`: The Kafka SASL password
+
+## Security Benefits
+
+- **No hardcoded credentials**: Credentials are stored securely in Kubernetes secrets
+- **Namespace isolation**: Secrets are namespace-scoped
+- **Access control**: Use Kubernetes RBAC to control access to secrets
+- **Rotation**: Credentials can be rotated by updating the secret
+
+## Example
+
+See the complete example in [config/samples/milvus_kafka_external_secret.yaml](../config/samples/milvus_kafka_external_secret.yaml).
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Secret not found**: Ensure the secret exists in the same namespace as the Milvus instance
+2. **Wrong keys**: Make sure the secret contains `username` and `password` keys
+3. **Permissions**: Verify the operator has permission to read secrets in the namespace
+
+### Debugging
+
+Check the operator logs for any error messages related to secret reading:
+
+```bash
+kubectl logs -n milvus-system deployment/milvus-operator
+```
+
+Look for messages like:
+```
+get kafka secret error: secrets "milvus-kafka-credentials" not found
+```


### PR DESCRIPTION
This PR adds support for external Kafka credentials through Kubernetes secrets, improving security by avoiding hardcoded credentials in configuration files.

## Changes:
- Add SecretRef field to MilvusKafka struct
- Add getKafkaCredentials function to retrieve credentials from secret
- Update updateConfigMap to inject Kafka credentials automatically
- Add example configuration and documentation

## Usage:
Users can now reference a Kubernetes secret containing Kafka credentials:
```yaml
dependencies:
  kafka:
    external: true
    secretRef: "kafka-credentials"
```

This follows the same pattern as MinIO credentials and is fully backward compatible.