### PR TITLE
use pidof instead of ps -C to find milvus process

### DIFF
--- a/pkg/controllers/component_condition.go
+++ b/pkg/controllers/component_condition.go
@@ -252,7 +252,7 @@ func ExecKillIfTerminating(ctx context.Context, podList *corev1.PodList) error {
 		logger := ctrl.LoggerFrom(ctx)
 		containerName := pod.Labels[AppLabelComponent]
 		logger.Info("kill milvus process", "pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name), "container", containerName)
-		stdout, stderr, err := cli.Exec(ctx, pod.Namespace, pod.Name, containerName, []string{"bash", "-c", "pid=$(ps -C milvus -o pid=); kill -9 $pid"})
+		stdout, stderr, err := cli.Exec(ctx, pod.Namespace, pod.Name, containerName, []string{"bash", "-c", "pid=$(pidof milvus); kill -9 $pid"})
 		if err != nil {
 			logger.Error(err, "kill milvus process err", "pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name), "container", containerName)
 			ret = err


### PR DESCRIPTION
The primary issue with `ps -C` is that it searches based on the process comm field, which represents the command name of the process. This comm field can sometimes reflect the name of an individual thread (e.g., CGO_LOAD) rather than the main process itself.
Using the `pidof` directly addresses the problem, which looks for the process whose original executable or command-line name is `milvus`.

