### PR TITLE
offline coords if using mixcoord

### DIFF
--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -165,6 +165,17 @@ func (c MilvusComponent) IsNode() bool {
 	return strings.HasSuffix(c.Name, "node")
 }
 
+func HasCoordsSpec(m *v1beta1.Milvus) bool {
+	return m.Spec.Com.DataCoord != nil || m.Spec.Com.QueryCoord != nil || m.Spec.Com.IndexCoord != nil || m.Spec.Com.RootCoord != nil
+}
+
+func SetCoordsNil(m *v1beta1.Milvus) {
+	m.Spec.Com.DataCoord = nil
+	m.Spec.Com.QueryCoord = nil
+	m.Spec.Com.IndexCoord = nil
+	m.Spec.Com.RootCoord = nil
+}
+
 // GetLeastReplicasRegardingHPA returns the least replicas for the component regarding HPA
 func (c MilvusComponent) GetLeastReplicasRegardingHPA(spec v1beta1.MilvusSpec) int32 {
 	replicas := ReplicasValue(c.GetReplicas(spec))


### PR DESCRIPTION
This pull request introduces a new mechanism to clean up non-mixcoord coordinators during the upgrade process in `Milvus` when transitioning to mixcoord mode. It includes utility functions, a new cleanup method, and corresponding unit tests to ensure proper functionality.

### New functionality for coordinator cleanup:

* **Utility functions added**:
  - `HasCoordsSpec` and `SetCoordsNil` functions were added to check for and reset coordinator specifications in the `Milvus` spec (`pkg/controllers/components.go`).

* **Cleanup logic implemented**:
  - A new method, `cleanupCoordinatorsIfNeeded`, was added to the `MilvusReconciler` to remove non-mixcoord coordinators if the system is in mixcoord mode and the image has been updated. This method deletes existing deployments for individual coordinators, resets their specifications, and updates the `Milvus` instance (`pkg/controllers/deployments.go`).

### Integration into reconciliation process:

* **Reconciliation update**:
  - The `ReconcileDeployments` method now invokes `cleanupCoordinatorsIfNeeded` as part of the reconciliation process to ensure coordinators are cleaned up when needed (`pkg/controllers/deployments.go`).

### Unit tests for cleanup functionality:

* **New test case**:
  - A unit test, `TestClusterReconciler_ReconcileDeployments_CleanupCoordinatorsIfNeeded`, was added to validate the behavior of the `cleanupCoordinatorsIfNeeded` method, including scenarios where cleanup is required and where it is not (`pkg/controllers/deployments_test.go`).

* **Import update**:
  - The `config` package was imported in the test file to support the new test case (`pkg/controllers/deployments_test.go`).