### PR TITLE
update the behavior: configMap changes will no longer cause pods to restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 1.3.0-rc1
+VERSION ?= 1.3.0-rc1-hotfix2
 TOOL_VERSION ?= 1.0.0
 MILVUS_HELM_VERSION ?= milvus-4.2.55
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ helm -n milvus-operator upgrade --install --create-namespace milvus-operator mil
 Or with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1-hotfix2/deploy/manifests/deployment.yaml
 ```
 
 For more infomation Check [Installation Instructions](docs/installation/installation.md)
@@ -135,11 +135,11 @@ Use helm:
 ```shell
 helm upgrade --install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1/milvus-operator-1.3.0-rc1.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1-hotfix2/milvus-operator-1.3.0-rc1-hotfix2.tgz
 ```
 
 Or use kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1-hotfix2/deploy/manifests/deployment.yaml
 ```

--- a/apis/milvus.io/v1beta1/milvus_webhook.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook.go
@@ -297,6 +297,7 @@ func (r *Milvus) DefaultComponents() {
 			r.Spec.Com.StreamingMode = util.BoolPtr(false)
 		}
 	}
+	r.Spec.Com.UpdateConfigMapOnly = true
 	r.defaultComponentsReplicas()
 }
 

--- a/apis/milvus.io/v1beta1/milvus_webhook_test.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook_test.go
@@ -65,6 +65,7 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 			},
 			EnableRollingUpdate: util.BoolPtr(false),
 			RollingMode:         RollingModeV2,
+			UpdateConfigMapOnly: true,
 		},
 		Conf: Values{
 			Data: map[string]interface{}{},
@@ -104,7 +105,8 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 	clusterDefault.Dep.Etcd.InCluster.Values.Data["replicaCount"] = int64(3)
 	delete(clusterDefault.Dep.Storage.InCluster.Values.Data, "mode")
 	clusterDefault.Com = MilvusComponents{
-		ImageUpdateMode: ImageUpdateModeRollingUpgrade,
+		ImageUpdateMode:     ImageUpdateModeRollingUpgrade,
+		UpdateConfigMapOnly: true,
 		ComponentSpec: ComponentSpec{
 			Image: config.DefaultMilvusImage,
 		},

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0-rc1
+version: 1.3.0-rc1-hotfix2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0-rc1"
+appVersion: "1.3.0-rc1-hotfix2"
 
 dependencies:
   - name: cert-manager

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v1.3.0-rc1"
+  tag: "v1.3.0-rc1-hotfix2"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-1.3.0-rc1
+    helm.sh/chart: milvus-operator-1.3.0-rc1-hotfix2
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0-rc1"
+    app.kubernetes.io/version: "1.3.0-rc1-hotfix2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -18166,10 +18166,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-1.3.0-rc1
+    helm.sh/chart: milvus-operator-1.3.0-rc1-hotfix2
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0-rc1"
+    app.kubernetes.io/version: "1.3.0-rc1-hotfix2"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -18187,10 +18187,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.0-rc1
+    helm.sh/chart: milvus-operator-1.3.0-rc1-hotfix2
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0-rc1"
+    app.kubernetes.io/version: "1.3.0-rc1-hotfix2"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-webhook-service'
   namespace: "milvus-operator"
@@ -18209,10 +18209,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.0-rc1
+    helm.sh/chart: milvus-operator-1.3.0-rc1-hotfix2
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0-rc1"
+    app.kubernetes.io/version: "1.3.0-rc1-hotfix2"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -18242,7 +18242,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v1.3.0-rc1'
+        image: 'milvusdb/milvus-operator:v1.3.0-rc1-hotfix2'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:

--- a/docs/administration/configure-milvus.md
+++ b/docs/administration/configure-milvus.md
@@ -70,6 +70,7 @@ spec:
   components:
     updateConfigMapOnly: true
 ```
+Since Milvus Operator v1.3.0, the `spec.components.updateConfigMapOnly` is force to be `true`, pods will not restart on ConfigMap changes.
 
 > Note: not all fields in the `milvus.yaml` can be dynamically updated. You can refer to the [Applicable configuration items](https://milvus.io/docs/dynamic_config.md#Applicable-configuration-items) for more details.
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,7 +12,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1/milvus-operator-1.3.0-rc1.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1-hotfix2/milvus-operator-1.3.0-rc1-hotfix2.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -20,7 +20,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1/milvus-operator-1.3.0-rc1.tgz \
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1-hotfix2/milvus-operator-1.3.0-rc1-hotfix2.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -39,7 +39,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1/milvus-operator-1.3.0-rc1.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0-rc1-hotfix2/milvus-operator-1.3.0-rc1-hotfix2.tgz
 ```
 
 ## Delete operator
@@ -62,7 +62,7 @@ If you don't want to use helm you can also install with kubectl and raw manifest
 ## Installation
 It is recommended to install the milvus operator with a newest stable version
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1-hotfix2/deploy/manifests/deployment.yaml
 ``` 
 
 Check the installed operators:
@@ -85,7 +85,7 @@ Same as installation, you can update the milvus operator with a newer version by
 Delete the milvus operator stack by the deployment manifest:
 
 ```shell
-kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1/deploy/manifests/deployment.yaml
+kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0-rc1-hotfix2/deploy/manifests/deployment.yaml
 ```
 
 Or delete the milvus operator stack by using makefile:


### PR DESCRIPTION
- Since Milvus configurations can take effect without a pod restart, `spec.components.updateConfigMapOnly` is automatically set to true, ensuring pods are not restarted when ConfigMaps are modified.

- bump milvus-operator version to 1.3.0-rc1-hotfix2