### PR TITLE
add milvus cluster woodpecker sample

### DIFF
--- a/config/samples/milvus_cluster_woodpecker.yaml
+++ b/config/samples/milvus_cluster_woodpecker.yaml
@@ -1,0 +1,14 @@
+# This is a sample to deploy a milvus cluster with woodpecker message stream.
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  mode: cluster
+  components: 
+    image: milvusdb/milvus:v2.6.0
+  config: {}
+  dependencies:
+    msgStreamType: woodpecker


### PR DESCRIPTION
This pull request adds a new sample YAML configuration file for deploying a Milvus cluster that uses the Woodpecker message stream. This provides an example setup for users who want to deploy Milvus with this specific message stream type.

Deployment configuration:

* Added `milvus_cluster_woodpecker.yaml` sample file to demonstrate how to deploy a Milvus cluster with `msgStreamType` set to `woodpecker`.