### PR TITLE
update bitnami repo, bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 1.3.0
+VERSION ?= 1.3.1
 TOOL_VERSION ?= 1.0.0
-MILVUS_HELM_VERSION ?= milvus-5.0.0
+MILVUS_HELM_VERSION ?= milvus-5.0.1
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)
 TOOL_RELEASE_IMG ?= milvusdb/milvus-config-tool:v$(TOOL_VERSION)
 KIND_CLUSTER ?= kind
@@ -239,10 +239,10 @@ sit-prepare-images: sit-prepare-operator-images
 	docker pull milvusdb/milvus:v2.6.0
 	
 	# docker pull -q apachepulsar/pulsar:2.8.2
-	docker pull -q bitnami/kafka:3.1.0-debian-10-r52
+	docker pull -q bitnamilegacy/kafka:3.1.0
 	docker pull -q milvusdb/etcd:3.5.18-r1
 	docker pull -q minio/minio:RELEASE.2024-12-18T13-15-44Z
-	docker pull -q bitnami/pymilvus:2.4.6
+	docker pull -q bitnamilegacy/pymilvus:2.4.6
 
 sit-load-operator-images:
 	@echo "Loading operator images"
@@ -252,16 +252,16 @@ sit-load-images: sit-load-operator-images
 	@echo "Loading images"
 	kind load docker-image milvusdb/milvus:v2.6.0
 	# kind load docker-image apachepulsar/pulsar:2.8.2 --name $(KIND_CLUSTER)
-	kind load docker-image bitnami/kafka:3.1.0-debian-10-r52 --name $(KIND_CLUSTER)
+	kind load docker-image bitnamilegacy/kafka:3.1.0 --name $(KIND_CLUSTER)
 	kind load docker-image milvusdb/etcd:3.5.18-r1 --name $(KIND_CLUSTER)
 	kind load docker-image minio/minio:RELEASE.2024-12-18T13-15-44Z --name $(KIND_CLUSTER)
-	kind load docker-image bitnami/pymilvus:2.4.6 --name $(KIND_CLUSTER)
+	kind load docker-image bitnamilegacy/pymilvus:2.4.6 --name $(KIND_CLUSTER)
 
 sit-load-and-cleanup-images: sit-load-images
 	@echo "Clean up some big images to save disk space in github action"
 	docker rmi milvusdb/milvus:v2.6.0
 	# docker rmi apachepulsar/pulsar:2.8.2
-	docker rmi bitnami/kafka:3.1.0-debian-10-r52
+	docker rmi bitnamilegacy/kafka:3.1.0
 	docker rmi milvusdb/etcd:3.5.18-r1
 	docker rmi minio/minio:RELEASE.2024-12-18T13-15-44Z
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ helm -n milvus-operator upgrade --install --create-namespace milvus-operator mil
 Or with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.1/deploy/manifests/deployment.yaml
 ```
 
 For more information Check [Installation Instructions](docs/installation/installation.md)
@@ -135,11 +135,11 @@ Use helm:
 ```shell
 helm upgrade --install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0/milvus-operator-1.3.0.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.1/milvus-operator-1.3.1.tgz
 ```
 
 Or use kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.1/deploy/manifests/deployment.yaml
 ```

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 
 dependencies:
   - name: cert-manager

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v1.3.0"
+  tag: "v1.3.1"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-1.3.0
+    helm.sh/chart: milvus-operator-1.3.1
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -18166,10 +18166,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-1.3.0
+    helm.sh/chart: milvus-operator-1.3.1
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -18187,10 +18187,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.0
+    helm.sh/chart: milvus-operator-1.3.1
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-webhook-service'
   namespace: "milvus-operator"
@@ -18209,10 +18209,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.0
+    helm.sh/chart: milvus-operator-1.3.1
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -18242,7 +18242,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v1.3.0'
+        image: 'milvusdb/milvus-operator:v1.3.1'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,7 +12,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0/milvus-operator-1.3.0.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.1/milvus-operator-1.3.1.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -20,7 +20,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0/milvus-operator-1.3.0.tgz \
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.1/milvus-operator-1.3.1.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -39,7 +39,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.0/milvus-operator-1.3.0.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.1/milvus-operator-1.3.1.tgz
 ```
 
 ## Delete operator
@@ -62,7 +62,7 @@ If you don't want to use helm you can also install with kubectl and raw manifest
 ## Installation
 It is recommended to install the milvus operator with a newest stable version
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.1/deploy/manifests/deployment.yaml
 ``` 
 
 Check the installed operators:
@@ -85,7 +85,7 @@ Same as installation, you can update the milvus operator with a newer version by
 Delete the milvus operator stack by the deployment manifest:
 
 ```shell
-kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.0/deploy/manifests/deployment.yaml
+kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.1/deploy/manifests/deployment.yaml
 ```
 
 Or delete the milvus operator stack by using makefile:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -26,7 +26,7 @@ ${SED} "s|milvus-operator/.*/deploy/manifests/deployment.yaml|milvus-operator/v$
 ${SED} "s|milvusdb/milvus:.*|milvusdb/milvus:v${MILVUS_VERSION}|g" ./Makefile
 ${SED} "s/Versions, v.* \`/Versions, v${MILVUS_VERSION} \`/g" ./README.md
 ${SED} "s/Versions| v.* \`/Versions| v${MILVUS_VERSION} \`/g" ./README.md
-${SED} "s/DefaultMilvusVersion   = \"v.*\"/DefaultMilvusVersion   = \"v${MILVUS_VERSION}\"/g" ./pkg/config/config.go
+${SED} "s/DefaultMilvusVersion = \"v.*\"/DefaultMilvusVersion = \"v${MILVUS_VERSION}\"/g" ./pkg/config/config.go
 # milvus-helm version
 ${SED} "s/^MILVUS_HELM_VERSION ?= milvus-.*/MILVUS_HELM_VERSION ?= milvus-${MILVUS_HELM_VERSION}/g" ./Makefile
 

--- a/test/hello-milvus-job.yaml
+++ b/test/hello-milvus-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hello-milvus
-        image: bitnami/pymilvus:2.4.6
+        image: bitnamilegacy/pymilvus:2.4.6
         command: 
           - "python3"
         args:


### PR DESCRIPTION
This pull request updates the Milvus Operator to version 1.3.1 and makes related changes throughout the codebase to ensure consistency and compatibility. It also updates several image references to use the `bitnamilegacy` repository instead of `bitnami` for certain dependencies.

Version and image updates:

* Bump Milvus Operator version to 1.3.1 across all relevant files, including `Makefile`, Helm chart (`Chart.yaml`, `values.yaml`), deployment manifests, and documentation. 

* Update `MILVUS_HELM_VERSION` in the `Makefile` from `milvus-5.0.0` to `milvus-5.0.1`.

Dependency image repository changes:

* Switch Kafka and PyMilvus images from `bitnami` to `bitnamilegacy` in `Makefile` and test resources to address upstream changes or deprecations. 

These changes ensure the operator and its documentation are aligned with the new release and that dependencies are pulled from maintained sources.