### PR TITLE
bump go version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zilliztech/milvus-operator
 
-go 1.24.2
+go 1.24.6
 
 require (
 	cloud.google.com/go/storage v1.39.1


### PR DESCRIPTION
This pull request updates the Go version used in the project to ensure compatibility with the latest features and security patches.

Dependency update:

* Updated the Go version in `go.mod` from `1.24.2` to `1.24.6` to use the latest stable release.