### PR TITLE
podmonitor: support collect from pods not managed by operator

### DIFF
--- a/pkg/controllers/podmonitor.go
+++ b/pkg/controllers/podmonitor.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"maps"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -77,7 +78,9 @@ func (r *MilvusReconciler) updatePodMonitor(
 	podmonitor.Spec.NamespaceSelector = monitoringv1.NamespaceSelector{
 		MatchNames: []string{mc.Namespace},
 	}
-	podmonitor.Spec.Selector.MatchLabels = appLabels
+	matchLabels := maps.Clone(appLabels)
+	delete(matchLabels, AppLabelManagedBy)
+	podmonitor.Spec.Selector.MatchLabels = matchLabels
 	podmonitor.Spec.PodTargetLabels = []string{
 		AppLabelInstance, AppLabelName, AppLabelComponent,
 	}


### PR DESCRIPTION
This pull request introduces a minor improvement to the way label selectors are handled in the PodMonitor reconciliation logic. The main change is that the `AppLabelManagedBy` label is now excluded from the PodMonitor's selector labels, which helps prevent unnecessary label matching and potential issues with monitoring configuration.

Label selector handling:

* [`pkg/controllers/podmonitor.go`](diffhunk://#diff-43b11937b76a42fcbfac81d85d5aff50b5e917e397d32cbd91d2fb0871c78f15R5): Imports the `maps` package to efficiently clone maps, and updates the PodMonitor selector logic to remove the `AppLabelManagedBy` label from `appLabels` before assigning to `podmonitor.Spec.Selector.MatchLabels`. [[1]](diffhunk://#diff-43b11937b76a42fcbfac81d85d5aff50b5e917e397d32cbd91d2fb0871c78f15R5) [[2]](diffhunk://#diff-43b11937b76a42fcbfac81d85d5aff50b5e917e397d32cbd91d2fb0871c78f15L80-R83)