### PR TITLE
fix: update milvus-operator chart URL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -22,7 +22,7 @@ entries:
     name: milvus-operator
     type: application
     urls:
-    - https://github.com/zilliztech/milvus-operator/releases/download/milvus-operator-1.3.2/milvus-operator-1.3.2.tgz
+    - https://github.com/zilliztech/milvus-operator/releases/download/v1.3.2/milvus-operator-1.3.2.tgz
     version: 1.3.2
   - apiVersion: v2
     appVersion: 1.3.1


### PR DESCRIPTION
The previous Helm chart URL for the Milvus Operator was incorrect, causing failures when deploying the operator. This commit updates the URL to point to the correct repository, ensuring successful Helm installations.