### PR TITLE
fix(version): handle images containing multiple colons

### DIFF
--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -133,10 +133,10 @@ func isImageVersionGreaterThan2_6(version, image string) bool {
 	// use tag if version is not set, parse format: registry/namespace/image:tag
 	parts := strings.Split(image, ":")
 
-	if len(parts) != 2 {
+	if len(parts) < 2 {
 		return false
 	}
-	imageTag := parts[1]
+	imageTag := parts[len(parts)-1]
 	if strings.HasPrefix(imageTag, "master-") {
 		return true
 	}

--- a/apis/milvus.io/v1beta1/milvus_types_test.go
+++ b/apis/milvus.io/v1beta1/milvus_types_test.go
@@ -341,3 +341,29 @@ func TestMilvus_setDefaultMsgStreamType(t *testing.T) {
 	})
 
 }
+
+func TestIsImageVersionGreaterThan2_6(t *testing.T) {
+	t.Run("image with more than one colon is less than 2.6", func(t *testing.T) {
+		assert.False(t, isImageVersionGreaterThan2_6("", "10.20.12.8:5000/milvusdb/milvus:v2.5.0"))
+	})
+
+	t.Run("image with more than one colon is greater than 2.6", func(t *testing.T) {
+		assert.True(t, isImageVersionGreaterThan2_6("", "10.20.12.8:5000/milvusdb/milvus:v2.6.0"))
+	})
+
+	t.Run("tag version is less than 2.6", func(t *testing.T) {
+		assert.False(t, isImageVersionGreaterThan2_6("", "milvusdb/milvus:v2.5.0"))
+	})
+
+	t.Run("tag version is greater than 2.6", func(t *testing.T) {
+		assert.True(t, isImageVersionGreaterThan2_6("", "milvusdb/milvus:v2.6.0"))
+	})
+
+	t.Run("version is less than 2.6", func(t *testing.T) {
+		assert.False(t, isImageVersionGreaterThan2_6("v2.5.0", "milvusdb/milvus:20250209-200000"))
+	})
+
+	t.Run("version is greater than 2.6", func(t *testing.T) {
+		assert.True(t, isImageVersionGreaterThan2_6("v2.6.1", "milvusdb/milvus:20250809-100000"))
+	})
+}


### PR DESCRIPTION
This pull request improves the logic for parsing image tags in the `isImageVersionGreaterThan2_6` function and adds comprehensive unit tests to ensure correct behavior for different image formats and version scenarios.

Image tag parsing improvements:

* Updated the logic in `isImageVersionGreaterThan2_6` (in `milvus_types.go`) to handle image strings with multiple colons by extracting the tag from the last segment, making the version comparison more robust.

Test coverage enhancements:

* Added a new test function `TestIsImageVersionGreaterThan2_6` (in `milvus_types_test.go`) to verify the function with various image formats and version cases, including images with multiple colons and different version tags.