### PR TITLE
enhance: run using the Milvus UID instead of the root

### DIFF
--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -100,7 +100,7 @@ func updatePodTemplate(
 	if updater.GetMilvus().Spec.Com.RunAsNonRoot {
 		template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsNonRoot: &updater.GetMilvus().Spec.Com.RunAsNonRoot,
-			RunAsUser:    int64Ptr(1000),
+			RunAsUser:    int64Ptr(999),
 		}
 	}
 

--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -405,7 +405,7 @@ func renderInitContainer(container *corev1.Container, toolImage string) *corev1.
 	}
 	container.SecurityContext = &corev1.SecurityContext{
 		RunAsNonRoot: boolPtr(true),
-		RunAsUser:    int64Ptr(1000),
+		RunAsUser:    int64Ptr(999),
 	}
 	fillContainerDefaultValues(container)
 	return container


### PR DESCRIPTION
This pull request makes a minor update to the security context configuration for pods and containers in the deployment controller. The main change is updating the default user ID from 1000 to 999 for processes running as non-root.

Milvus Dockerfile update: https://github.com/milvus-io/milvus/commit/7cb765152395fd28d76b84e8f2254da86f0d909b. The new Milvus image will default to use `milvus` to run the entrypoint of the container process, whose UID is 999.