### PR TITLE
bump etcd image to 3.5.23-r2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
 VERSION ?= 1.3.3
 TOOL_VERSION ?= 1.0.0
-MILVUS_HELM_VERSION ?= milvus-5.0.7
+MILVUS_HELM_VERSION ?= milvus-5.0.9
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)
 TOOL_RELEASE_IMG ?= milvusdb/milvus-config-tool:v$(TOOL_VERSION)
 KIND_CLUSTER ?= kind
@@ -240,7 +240,7 @@ sit-prepare-images: sit-prepare-operator-images
 	
 	# docker pull -q apachepulsar/pulsar:2.8.2
 	docker pull -q bitnamilegacy/kafka:3.1.0
-	docker pull -q milvusdb/etcd:3.5.18-r1
+	docker pull -q milvusdb/etcd:3.5.23-r2
 	docker pull -q minio/minio:RELEASE.2024-12-18T13-15-44Z
 	docker pull -q bitnamilegacy/pymilvus:2.4.6
 
@@ -253,7 +253,7 @@ sit-load-images: sit-load-operator-images
 	kind load docker-image milvusdb/milvus:v2.6.5
 	# kind load docker-image apachepulsar/pulsar:2.8.2 --name $(KIND_CLUSTER)
 	kind load docker-image bitnamilegacy/kafka:3.1.0 --name $(KIND_CLUSTER)
-	kind load docker-image milvusdb/etcd:3.5.18-r1 --name $(KIND_CLUSTER)
+	kind load docker-image milvusdb/etcd:3.5.23-r2 --name $(KIND_CLUSTER)
 	kind load docker-image minio/minio:RELEASE.2024-12-18T13-15-44Z --name $(KIND_CLUSTER)
 	kind load docker-image bitnamilegacy/pymilvus:2.4.6 --name $(KIND_CLUSTER)
 
@@ -262,7 +262,7 @@ sit-load-and-cleanup-images: sit-load-images
 	docker rmi milvusdb/milvus:v2.6.5
 	# docker rmi apachepulsar/pulsar:2.8.2
 	docker rmi bitnamilegacy/kafka:3.1.0
-	docker rmi milvusdb/etcd:3.5.18-r1
+	docker rmi milvusdb/etcd:3.5.23-r2
 	docker rmi minio/minio:RELEASE.2024-12-18T13-15-44Z
 
 sit-generate-manifest:


### PR DESCRIPTION
This pull request updates the `Makefile` to use newer versions of Milvus Helm and the Milvus etcd Docker image for SIT (System Integration Testing) workflows. These changes ensure that the SIT environment is aligned with the latest compatible releases, improving stability and consistency.

**Version updates for SIT environment:**

* Updated `MILVUS_HELM_VERSION` from `milvus-5.0.7` to `milvus-5.0.9` to use the latest Milvus Helm chart for deployments.

**etcd Docker image version alignment:**

* Changed the etcd image version from `milvusdb/etcd:3.5.18-r1` to `milvusdb/etcd:3.5.23-r2` in the image pull, load, and cleanup steps to ensure consistency across SIT workflows. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L243-R243) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L256-R256) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L265-R265)