### PR TITLE
feat(helm): add `extraArgs` support for milvus-operator deployment

### DIFF
--- a/charts/milvus-operator/templates/deployment.yaml
+++ b/charts/milvus-operator/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{- if .Values.enableWebhook }}
         - --webhook=true
         {{- end }}
+        {{- with .Values.extraArgs }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         command:
         - /manager
         image: '{{.Values.image.repository}}:{{.Values.image.tag|default .Chart.AppVersion}}'

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -195,3 +195,9 @@ tolerations: []
 #   }
 # }`
 affinity: {}
+
+# extraArgs -- Additional arguments to pass to the controller container
+extraArgs: []
+#  - --debug
+#  - --k8s-qps=50
+#  - --watche-namespace=test-namespace1,test-namespace2


### PR DESCRIPTION
The current milvus-operator helm chart does not pass runtime flags supported by the operator (e.g., `--debug`, `--watch-namespace`).

Since these flags are very useful for testing, this PR adds an `extraArgs` field to allow passing them through Helm values.