### PR TITLE
fixed upgrade from 2.5.x to 2.6.x, by first upgrading the mixcoord

### DIFF
--- a/pkg/controllers/dependency_graph.go
+++ b/pkg/controllers/dependency_graph.go
@@ -60,9 +60,9 @@ func init() {
 	streamingNodeClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})
 	streamingNodeClusterDependencyGraph.AddDependency(Proxy, []MilvusComponent{DataNode})
 
-	upgrade26ClusterDependencyGraph.AddDependency(StreamingNode, []MilvusComponent{})
-	upgrade26ClusterDependencyGraph.AddDependency(MixCoord, []MilvusComponent{StreamingNode})
-	upgrade26ClusterDependencyGraph.AddDependency(QueryNode, []MilvusComponent{MixCoord})
+	upgrade26ClusterDependencyGraph.AddDependency(MixCoord, []MilvusComponent{})
+	upgrade26ClusterDependencyGraph.AddDependency(StreamingNode, []MilvusComponent{MixCoord})
+	upgrade26ClusterDependencyGraph.AddDependency(QueryNode, []MilvusComponent{StreamingNode})
 	upgrade26ClusterDependencyGraph.AddDependency(DataNode, []MilvusComponent{QueryNode})
 	upgrade26ClusterDependencyGraph.AddDependency(Proxy, []MilvusComponent{DataNode})
 }


### PR DESCRIPTION
fixed upgrade from 2.5.x to 2.6.x, by first upgrading the mixcoord, before deploying the streaming node. streaming node needs 2.6.x before it can become healthy.

Haven't fully tested this but want to get your feedback on this. Do you think this is the real issue?

This PR tries to fix #446 

If you think this is the right approach I will fix the DCO and anything else that might need fixing.