### PR TITLE
fix(rollout): skip evicted pods in deploy pod list

### DIFF
--- a/pkg/controllers/rollout_util.go
+++ b/pkg/controllers/rollout_util.go
@@ -170,7 +170,14 @@ func (c *K8sUtilImpl) ListDeployPods(ctx context.Context, deploy *appsv1.Deploym
 	if err != nil {
 		return nil, errors.Wrap(err, "list pods")
 	}
-	return pods.Items, nil
+	ret := []corev1.Pod{}
+	for _, pod := range pods.Items {
+		if pod.Status.Reason == "Evicted" {
+			continue
+		}
+		ret = append(ret, pod)
+	}
+	return ret, nil
 }
 
 func (c *K8sUtilImpl) DeploymentIsStable(deploy *appsv1.Deployment, allPods []corev1.Pod) (isStable bool, reason string) {


### PR DESCRIPTION
When a pod is evicted, it remains while the ReplicaSet creates a replacement, which can cause an unexpected pod count during deployment stability checks.

This pull request improves the robustness of the `ListDeployPods` function by filtering out pods that have been evicted. 
Additionally, it adds a unit test to ensure this filtering logic works as expected. 

**Pod filtering enhancements:**

* Updated the `ListDeployPods` method in `rollout_util.go` to exclude pods with status reason "Evicted" from its results.

**Testing improvements:**

* Added a test case in `rollout_util_test.go` to verify that evicted pods are filtered out.