### PR TITLE
fix: make milvus `spec.components.updateConfigMapOnly` a pointer and default to `true`

### DIFF
--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -206,7 +206,8 @@ type MilvusComponents struct {
 
 	// UpdateConfigMapOnly when enabled, will not rollout pods. By default pods will be restarted when configmap changed
 	// +kubebuilder:validation:Optional
-	UpdateConfigMapOnly bool `json:"updateConfigMapOnly,omitempty"`
+	// +nullable
+	UpdateConfigMapOnly *bool `json:"updateConfigMapOnly,omitempty"`
 
 	// RollingMode is the rolling mode for milvus components, default to 2
 	// +kubebuilder:validation:Optional

--- a/apis/milvus.io/v1beta1/milvus_types.go
+++ b/apis/milvus.io/v1beta1/milvus_types.go
@@ -557,6 +557,13 @@ func (m *Milvus) IsRollingUpdateEnabled() bool {
 	return m.Spec.Com.EnableRollingUpdate != nil && *m.Spec.Com.EnableRollingUpdate
 }
 
+func (m *Milvus) IsUpdateConfigMapOnly() bool {
+	if m.Spec.Com.UpdateConfigMapOnly == nil {
+		return true
+	}
+	return *m.Spec.Com.UpdateConfigMapOnly
+}
+
 // +kubebuilder:object:root=true
 // MilvusList contains a list of Milvus
 type MilvusList struct {

--- a/apis/milvus.io/v1beta1/milvus_webhook.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook.go
@@ -297,7 +297,9 @@ func (r *Milvus) DefaultComponents() {
 			r.Spec.Com.StreamingMode = util.BoolPtr(false)
 		}
 	}
-	r.Spec.Com.UpdateConfigMapOnly = true
+	if r.Spec.Com.UpdateConfigMapOnly == nil {
+		r.Spec.Com.UpdateConfigMapOnly = util.BoolPtr(true)
+	}
 	r.defaultComponentsReplicas()
 }
 

--- a/apis/milvus.io/v1beta1/milvus_webhook_test.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook_test.go
@@ -65,7 +65,7 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 			},
 			EnableRollingUpdate: util.BoolPtr(true),
 			RollingMode:         RollingModeV2,
-			UpdateConfigMapOnly: true,
+			UpdateConfigMapOnly: util.BoolPtr(true),
 		},
 		Conf: Values{
 			Data: map[string]interface{}{},
@@ -107,7 +107,7 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 	delete(clusterDefault.Dep.Storage.InCluster.Values.Data, "mode")
 	clusterDefault.Com = MilvusComponents{
 		ImageUpdateMode:     ImageUpdateModeRollingUpgrade,
-		UpdateConfigMapOnly: true,
+		UpdateConfigMapOnly: util.BoolPtr(true),
 		ComponentSpec: ComponentSpec{
 			Image: config.DefaultMilvusImage,
 		},

--- a/apis/milvus.io/v1beta1/zz_generated.deepcopy.go
+++ b/apis/milvus.io/v1beta1/zz_generated.deepcopy.go
@@ -264,6 +264,11 @@ func (in *MilvusComponents) DeepCopyInto(out *MilvusComponents) {
 			(*out)[key] = val
 		}
 	}
+	if in.UpdateConfigMapOnly != nil {
+		in, out := &in.UpdateConfigMapOnly, &out.UpdateConfigMapOnly
+		*out = new(bool)
+		**out = **in
+	}
 	if in.StreamingMode != nil {
 		in, out := &in.StreamingMode, &out.StreamingMode
 		*out = new(bool)

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -133,7 +133,6 @@ func updateNetworkSettings(template *corev1.PodTemplateSpec, updater deploymentU
 
 func updatePodMeta(template *corev1.PodTemplateSpec, appLabels map[string]string, updater deploymentUpdater) {
 	mergedComSpec := updater.GetMergedComponentSpec()
-	spec := updater.GetMilvus().Spec
 	if template.Labels == nil {
 		template.Labels = map[string]string{}
 	}
@@ -143,7 +142,8 @@ func updatePodMeta(template *corev1.PodTemplateSpec, appLabels map[string]string
 		template.Annotations = map[string]string{}
 	}
 	template.Annotations = MergeAnnotations(template.Annotations, mergedComSpec.PodAnnotations)
-	if !spec.Com.UpdateConfigMapOnly {
+	m := updater.GetMilvus()
+	if !m.IsUpdateConfigMapOnly() {
 		template.Annotations[AnnotationCheckSum] = updater.GetConfCheckSum()
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where `updateConfigMapOnly` was effectively forced to `true`, preventing users from explicitly setting it to `false`.

### Changes
- Change `updateConfigMapOnly` type from `bool` to `*bool`.
- Update logic to treat `nil` as `true` (default), while respecting an explicit `false`.

## Related Issue

Fixes #455

cc. @haorenfsa 