### PR TITLE
enhance(ci): switch arm builds to GitHub-hosted ARM64 runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,13 +11,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Prepare
         run: |
@@ -34,8 +36,6 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to Docker Hub


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Docker images to support multiple platforms. Instead of relying on the AMD runner with QEMU to build ARM images, it now uses a native ARM64 runner.

Workflow improvements:

* Updated the `build` job in `.github/workflows/docker-image.yml` to use a matrix that specifies both the `platform` and a corresponding `runner`, allowing builds to run on `ubuntu-24.04` for `linux/amd64` and `ubuntu-24.04-arm` for `linux/arm64`.

This improvement cuts the build process down from 30 minutes to only 3 minutes.