### PR TITLE
feat(deps): support chart version pinning for etcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,13 +116,17 @@ out/config/assets/templates:
 
 docker-prepare: build-release out/config/assets/templates
 	mkdir -p ./out/config/assets/charts/
-	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/etcd-8.12.0.tgz -O ./etcd.tgz
+	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/etcd-8.12.0.tgz -O ./etcdv8.tgz
+	wget https://charts.bitnami.com/bitnami/etcd-6.3.3.tgz -O ./etcdv6.tgz
 	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/minio-8.0.17.tgz -O ./minio.tgz
 	wget https://github.com/apache/pulsar-helm-chart/releases/download/pulsar-2.7.8/pulsar-2.7.8.tgz -O ./pulsar.tgz
 	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/pulsar-3.3.0.tgz -O ./pulsarv3.tgz
 	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/kafka-15.5.1.tgz -O ./kafka.tgz
 	wget https://github.com/zilliztech/milvus-helm/raw/${MILVUS_HELM_VERSION}/charts/milvus/charts/tei-1.6.0.tgz -O ./tei.tgz
-	tar -xf ./etcd.tgz -C ./out/config/assets/charts/
+	tar -xf ./etcdv8.tgz -C ./out/config/assets/
+	mv ./out/config/assets/etcd ./out/config/assets/charts/etcdv8
+	tar -xf ./etcdv6.tgz -C ./out/config/assets/
+	mv ./out/config/assets/etcd ./out/config/assets/charts/etcdv6
 	tar -xf ./minio.tgz -C ./out/config/assets/charts/
 	tar -xf ./pulsarv3.tgz -C ./out/config/assets/
 	mv ./out/config/assets/pulsar ./out/config/assets/charts/pulsarv3

--- a/apis/milvus.io/v1beta1/dependencies_types.go
+++ b/apis/milvus.io/v1beta1/dependencies_types.go
@@ -98,12 +98,12 @@ type InClusterConfig struct {
 	// +nullable
 	Values Values `json:"values,omitempty"`
 
-	// ChartVersion is the pulsar chart version to be installed
-	// For now only pulsar uses this field
-	// pulsar-v2 (v2.7.8) & pulsar-v3 (v3.3.0) can be used
-	// after v1.2.0, pulsar-v3 is used for new milvus
-	// note it's the version of chart, not pulsar
-	// pulsar v2.x should use pulsar-v2 chart, & pulsar v3.x should use pulsar-v3 chart
+	// ChartVersion is the Helm chart version to be installed.
+	// Supported values:
+	// - For Pulsar: pulsar-v2 (chart 2.7.8) & pulsar-v3 (chart 3.3.0), after v1.2.0 pulsar-v3 is used for new Milvus.
+	// - For Etcd: etcd-v6 (chart 6.3.3) & etcd-v8 (chart 8.12.0), after v1.3.3 etcd-v8 is used for new Milvus.
+	// Note: this is the version of the Helm chart, not the underlying component (Pulsar, Etcd, etc.).
+	// Pulsar v2.x should use the pulsar-v2 chart and Pulsar v3.x should use the pulsar-v3 chart.
 	// +kubebuilder:validation:Optional
 	ChartVersion values.ChartVersion `json:"chartVersion,omitempty"`
 

--- a/apis/milvus.io/v1beta1/milvus_webhook.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook.go
@@ -396,6 +396,15 @@ func (r *Milvus) defaultEtcd() {
 		if r.Spec.Dep.Etcd.InCluster.Values.Data == nil {
 			r.Spec.Dep.Etcd.InCluster.Values.Data = map[string]interface{}{}
 		}
+
+		// Set ChartVersion for new deployments only
+		// For existing deployments, leave empty - will be filled during reconciliation
+		if r.Spec.Dep.Etcd.InCluster.ChartVersion == "" {
+			if r.IsFirstTimeStarting() {
+				r.Spec.Dep.Etcd.InCluster.ChartVersion = values.ChartVersionEtcdV8
+			}
+		}
+
 		etcdReplicaCountNumber, etcdReplicaCountValid := util.GetNumberValue(r.Spec.Dep.Etcd.InCluster.Values.Data, "replicaCount")
 		var etcdReplicaCount int
 		if !etcdReplicaCountValid {

--- a/apis/milvus.io/v1beta1/milvus_webhook_test.go
+++ b/apis/milvus.io/v1beta1/milvus_webhook_test.go
@@ -33,6 +33,7 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 
 	etcdStandaloneDefaultInClusterConfig := defaultInClusterConfig.DeepCopy()
 	etcdStandaloneDefaultInClusterConfig.Values.Data["replicaCount"] = int64(1)
+	etcdStandaloneDefaultInClusterConfig.ChartVersion = "etcd-v8"
 	minioStandAloneDefaultInClusterConfig := defaultInClusterConfig.DeepCopy()
 	minioStandAloneDefaultInClusterConfig.Values.Data["mode"] = "standalone"
 
@@ -103,6 +104,8 @@ func TestMilvus_Default_NotExternal(t *testing.T) {
 		"mc-etcd-1.mc-etcd-headless.default:2379",
 		"mc-etcd-2.mc-etcd-headless.default:2379",
 	}
+
+	clusterDefault.Dep.Etcd.InCluster.ChartVersion = "etcd-v8"
 	clusterDefault.Dep.Etcd.InCluster.Values.Data["replicaCount"] = int64(3)
 	delete(clusterDefault.Dep.Storage.InCluster.Values.Data, "mode")
 	clusterDefault.Com = MilvusComponents{

--- a/docs/administration/manage-dependencies/meta-storage.md
+++ b/docs/administration/manage-dependencies/meta-storage.md
@@ -28,6 +28,31 @@ Fields used to configure an external etcd service include:
 # Internal etcd
 By default, Milvus Operator deploy an in-cluster etcd for milvus. Usually we need to configure the etcd's resources and replicas.
 
+## Etcd Chart Version
+
+The operator supports two etcd chart versions. Use `spec.dependencies.etcd.inCluster.chartVersion` to specify:
+
+| Value | Chart Version | Notes |
+|-------|---------------|-------|
+| `etcd-v6` | 6.3.3 | Legacy version |
+| `etcd-v8` | 8.12.0 | Default for new deployments |
+
+**Breaking change from v6 to v8:** The RBAC config field changed from `auth.rbac.enabled` to `auth.rbac.create`, and v8 enables RBAC by default.
+
+If you previously disabled RBAC in v6, upgrading to v8 requires:
+
+```yaml
+spec:
+  dependencies:
+    etcd:
+      inCluster:
+        chartVersion: "etcd-v8"
+        values:
+          auth:
+            rbac:
+              create: false  # New field name (replaces 'enabled')
+```
+
 ## Example
 
 ```yaml

--- a/pkg/controllers/dependencies.go
+++ b/pkg/controllers/dependencies.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	appsv1 "k8s.io/api/apps/v1"
@@ -443,9 +445,78 @@ func (r *MilvusReconciler) ReconcileEtcd(ctx context.Context, mc v1beta1.Milvus)
 	if mc.Spec.Dep.Etcd.External {
 		return nil
 	}
-	request := helm.GetChartRequest(mc, values.DependencyKindEtcd, Etcd)
 
+	// Ensure ChartVersion is populated (only fills if empty)
+	if err := r.ensureEtcdChartVersion(ctx, &mc); err != nil {
+		return err
+	}
+
+	request := helm.GetChartRequest(mc, values.DependencyKindEtcd, Etcd)
 	return r.helmReconciler.Reconcile(ctx, request, mc)
+}
+
+// ensureEtcdChartVersion ensures ChartVersion is set in the CR.
+// If already set, it returns immediately.
+// If not set, it detects from existing helm release (v6 or v8 based on major version),
+// or defaults to v8 for new deployments. The detected version is persisted to the CR.
+func (r *MilvusReconciler) ensureEtcdChartVersion(ctx context.Context, mc *v1beta1.Milvus) error {
+	if mc.Spec.Dep.Etcd.InCluster == nil {
+		return errors.New("etcd inCluster config is required when etcd is not external")
+	}
+
+	// If ChartVersion is already set, no need to detect
+	if mc.Spec.Dep.Etcd.InCluster.ChartVersion != "" {
+		return nil
+	}
+
+	// ChartVersion is empty, need to detect from actual Helm release
+	releaseName := mc.Name + "-etcd"
+	helmCfg := r.helmReconciler.NewHelmCfg(mc.Namespace)
+
+	exist, err := helm.ReleaseExist(helmCfg, releaseName)
+	if err != nil {
+		return err
+	}
+
+	var detectedVersion values.ChartVersion
+	if !exist {
+		// No existing release, will use default v8
+		detectedVersion = values.ChartVersionEtcdV8
+	} else {
+		// Get release info to determine chart version
+		chartVersionStr, err := helm.GetChartVersion(helmCfg, releaseName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get etcd chart version from helm release %s", releaseName)
+		}
+
+		// Parse semantic version
+		ver, err := semver.ParseTolerant(chartVersionStr)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse etcd chart version %s as semantic version", chartVersionStr)
+		}
+
+		// Determine version based on major version
+		switch ver.Major {
+		case 6:
+			detectedVersion = values.ChartVersionEtcdV6
+		case 8:
+			detectedVersion = values.ChartVersionEtcdV8
+		default:
+			return errors.Errorf("unsupported etcd chart version %s, only major version 6 or 8 are supported", chartVersionStr)
+		}
+	}
+
+	// Update the CR with detected version
+	mc.Spec.Dep.Etcd.InCluster.ChartVersion = detectedVersion
+	if err := r.Update(ctx, mc); err != nil {
+		return err
+	}
+
+	ctrl.LoggerFrom(ctx).Info("etcd ChartVersion detected and set",
+		"chartVersion", detectedVersion,
+		"releaseName", releaseName)
+
+	return nil
 }
 
 func (r *MilvusReconciler) ReconcileMsgStream(ctx context.Context, mc v1beta1.Milvus) error {

--- a/pkg/controllers/dependencies_test.go
+++ b/pkg/controllers/dependencies_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/zilliztech/milvus-operator/apis/milvus.io/v1beta1"
 	"github.com/zilliztech/milvus-operator/pkg/helm"
+	"github.com/zilliztech/milvus-operator/pkg/helm/values"
 )
 
 func TestLocalHelmReconciler_ReconcilePanic(t *testing.T) {
@@ -295,11 +296,12 @@ func TestClusterReconciler_ReconcileDeps(t *testing.T) {
 	icc := new(v1beta1.InClusterConfig)
 
 	m.Spec.Dep.Etcd.InCluster = icc
+	m.Spec.Dep.Etcd.InCluster.ChartVersion = values.ChartVersionEtcdV8
 
 	// internal reconcile helm
 	mockHelm.EXPECT().Reconcile(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, request helm.ChartRequest, mc v1beta1.Milvus) error {
-			assert.Equal(t, request.Chart, helm.GetChartPathByName(Etcd))
+			assert.Equal(t, request.Chart, helm.GetChartPathByName(values.EtcdV8))
 			return nil
 		})
 	assert.NoError(t, r.ReconcileEtcd(ctx, m))
@@ -345,4 +347,71 @@ func TestClusterReconciler_ReconcileDeps(t *testing.T) {
 		assert.NoError(t, r.ReconcileTei(ctx, m))
 		m.Spec.Dep.Tei.Enabled = false
 	})
+}
+
+func TestEnsureEtcdChartVersion(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.checkMocks()
+	r := env.Reconciler
+	ctx := env.ctx
+	mockHelm := NewMockHelmReconciler(env.Ctrl)
+	r.helmReconciler = mockHelm
+
+	t.Run("external etcd skipped", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.External = true
+		assert.NoError(t, r.ensureEtcdChartVersion(ctx, &mc))
+	})
+
+	t.Run("nil InCluster error", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.InCluster = nil
+		err := r.ensureEtcdChartVersion(ctx, &mc)
+		assert.EqualError(t, err, "etcd inCluster config is required when etcd is not external")
+	})
+
+	t.Run("ChartVersion already set no error", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.InCluster.ChartVersion = values.ChartVersionEtcdV6
+		assert.NoError(t, r.ensureEtcdChartVersion(ctx, &mc))
+		assert.Equal(t, values.ChartVersionEtcdV6, mc.Spec.Dep.Etcd.InCluster.ChartVersion)
+	})
+
+	// Version detection tests
+	runDetectTest := func(name, chartVer string, expect values.ChartVersion, errContains string) {
+		t.Run(name, func(t *testing.T) {
+			mockHelmClient := helm.NewMockClient(env.Ctrl)
+			helm.SetDefaultClient(mockHelmClient)
+			mockHelm.EXPECT().NewHelmCfg(gomock.Any()).Return(&action.Configuration{})
+			mockHelmClient.EXPECT().ReleaseExist(gomock.Any(), "test-etcd").Return(chartVer != "", nil)
+			if chartVer != "" {
+				mockHelmClient.EXPECT().GetChartVersion(gomock.Any(), "test-etcd").Return(chartVer, nil)
+			}
+			if errContains == "" {
+				env.MockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			mc := v1beta1.Milvus{}
+			mc.Default()
+			mc.Name = "test"
+			mc.Spec.Dep.Etcd.InCluster.ChartVersion = ""
+			err := r.ensureEtcdChartVersion(ctx, &mc)
+
+			if errContains != "" {
+				assert.ErrorContains(t, err, errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, expect, mc.Spec.Dep.Etcd.InCluster.ChartVersion)
+			}
+		})
+	}
+
+	runDetectTest("not exist defaults v8", "", values.ChartVersionEtcdV8, "")
+	runDetectTest("detects v6", "6.3.3", values.ChartVersionEtcdV6, "")
+	runDetectTest("detects v8", "8.12.0", values.ChartVersionEtcdV8, "")
+	runDetectTest("unsupported version", "5.0.0", "", "unsupported")
+	runDetectTest("invalid semver", "invalid", "", "failed to parse")
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -126,6 +126,19 @@ func (d *LocalClient) Uninstall(cfg *action.Configuration, releaseName string) e
 	return nil
 }
 
+// GetChartVersion returns the chart version of a Helm release
+func (d *LocalClient) GetChartVersion(cfg *action.Configuration, releaseName string) (string, error) {
+	client := action.NewStatus(cfg)
+	rel, err := client.Run(releaseName)
+	if err != nil {
+		return "", err
+	}
+	if rel.Chart == nil || rel.Chart.Metadata == nil {
+		return "", errors.New("chart metadata not found in release")
+	}
+	return rel.Chart.Metadata.Version, nil
+}
+
 func GetChartPathByName(chart string) string {
 	return "config/assets/charts/" + chart
 }
@@ -134,10 +147,27 @@ func GetChartRequest(mc v1beta1.Milvus, dep values.DependencyKind, chart string)
 	inCluster := reflect.ValueOf(mc.Spec.Dep).FieldByName(string(dep)).
 		FieldByName("InCluster").Interface().(*v1beta1.InClusterConfig)
 	chartKind := chart
-	if inCluster.ChartVersion == values.ChartVersionPulsarV3 {
-		chart = values.PulsarV3
-		chartKind = values.Pulsar
+
+	// Handle Pulsar versions
+	if dep == values.DependencyKindPulsar {
+		if inCluster.ChartVersion == values.ChartVersionPulsarV3 {
+			chart = values.PulsarV3
+			chartKind = values.Pulsar
+		}
 	}
+
+	// Handle Etcd versions
+	if dep == values.DependencyKindEtcd {
+		switch inCluster.ChartVersion {
+		case values.ChartVersionEtcdV6:
+			chart = values.EtcdV6
+		case values.ChartVersionEtcdV8:
+			chart = values.EtcdV8
+		default:
+			chart = values.EtcdV8 // Default to v8 for new deployments
+		}
+	}
+
 	return ChartRequest{
 		ReleaseName: mc.Name + "-" + chartKind,
 		Namespace:   mc.Namespace,

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,38 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zilliztech/milvus-operator/apis/milvus.io/v1beta1"
+	"github.com/zilliztech/milvus-operator/pkg/helm/values"
+)
+
+func TestGetChartRequest_EtcdVersions(t *testing.T) {
+	t.Run("etcd-v6", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.InCluster.ChartVersion = values.ChartVersionEtcdV6
+		request := GetChartRequest(mc, values.DependencyKindEtcd, "etcd")
+		assert.Equal(t, GetChartPathByName(values.EtcdV6), request.Chart)
+		assert.Contains(t, request.ReleaseName, "-etcd")
+	})
+
+	t.Run("etcd-v8", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.InCluster.ChartVersion = values.ChartVersionEtcdV8
+		request := GetChartRequest(mc, values.DependencyKindEtcd, "etcd")
+		assert.Equal(t, GetChartPathByName(values.EtcdV8), request.Chart)
+		assert.Contains(t, request.ReleaseName, "-etcd")
+	})
+
+	t.Run("etcd default to v8", func(t *testing.T) {
+		mc := v1beta1.Milvus{}
+		mc.Default()
+		mc.Spec.Dep.Etcd.InCluster.ChartVersion = "" // empty defaults to v8
+		request := GetChartRequest(mc, values.DependencyKindEtcd, "etcd")
+		assert.Equal(t, GetChartPathByName(values.EtcdV8), request.Chart)
+	})
+}

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -12,6 +12,7 @@ type Client interface {
 	GetStatus(cfg *action.Configuration, releaseName string) (release.Status, error)
 	GetValues(cfg *action.Configuration, releaseName string) (map[string]interface{}, error)
 	ReleaseExist(cfg *action.Configuration, releaseName string) (bool, error)
+	GetChartVersion(cfg *action.Configuration, releaseName string) (string, error)
 	Upgrade(cfg *action.Configuration, request ChartRequest) error
 	Update(cfg *action.Configuration, request ChartRequest) error
 	Install(cfg *action.Configuration, request ChartRequest) error
@@ -36,6 +37,10 @@ func GetValues(cfg *action.Configuration, releaseName string) (map[string]interf
 
 func ReleaseExist(cfg *action.Configuration, releaseName string) (bool, error) {
 	return defaultClient.ReleaseExist(cfg, releaseName)
+}
+
+func GetChartVersion(cfg *action.Configuration, releaseName string) (string, error) {
+	return defaultClient.GetChartVersion(cfg, releaseName)
 }
 
 func Upgrade(cfg *action.Configuration, request ChartRequest) error {

--- a/pkg/helm/values/values.go
+++ b/pkg/helm/values/values.go
@@ -15,6 +15,8 @@ type ChartVersion string
 const (
 	ChartVersionPulsarV2 ChartVersion = "pulsar-v2"
 	ChartVersionPulsarV3 ChartVersion = "pulsar-v3"
+	ChartVersionEtcdV6   ChartVersion = "etcd-v6"
+	ChartVersionEtcdV8   ChartVersion = "etcd-v8"
 )
 
 const (
@@ -26,6 +28,8 @@ const (
 
 	// Chart names & values sub-fields in milvus-helm
 	Etcd     = "etcd"
+	EtcdV6   = "etcdv6" // etcd chart 6.3.3 directory
+	EtcdV8   = "etcdv8" // etcd chart 8.12.0 directory
 	Minio    = "minio"
 	Pulsar   = "pulsar"
 	PulsarV3 = "pulsarv3"

--- a/test/upgrade.sh
+++ b/test/upgrade.sh
@@ -16,3 +16,23 @@ helm list |grep -v NAME |awk '{print $3}' | xargs -I{} [ {} -eq "1" ]
 # check milvus pods no restart
 kubectl get pods
 kubectl get pods |grep -v NAME |awk '{print $4}' | xargs -I{} [ {} -eq "0" ]
+
+# Test: operator upgrade introduces support for multiple etcd chart versions (v6 and v8),
+# but etcd values change should preserve chart version (v6 stays v6, v8 stays v8)
+echo "Testing etcd values change..."
+ETCD_CHART_VERSION_BEFORE=$(helm get metadata my-release-etcd -o json | jq -r '.version')
+echo "Etcd chart version before: $ETCD_CHART_VERSION_BEFORE"
+
+# Change etcd values
+kubectl patch milvus my-release --type='merge' -p '{"spec":{"dependencies":{"etcd":{"inCluster":{"values":{"readinessProbe":{"periodSeconds":12}}}}}}}'
+sleep 30
+kubectl --timeout 5m wait --for=condition=MilvusReady milvus my-release
+
+ETCD_CHART_VERSION_AFTER=$(helm get metadata my-release-etcd -o json | jq -r '.version')
+echo "Etcd chart version after: $ETCD_CHART_VERSION_AFTER"
+
+if [ "$ETCD_CHART_VERSION_BEFORE" != "$ETCD_CHART_VERSION_AFTER" ]; then
+    echo "ERROR: Etcd chart version changed from $ETCD_CHART_VERSION_BEFORE to $ETCD_CHART_VERSION_AFTER"
+    exit 1
+fi
+echo "Etcd chart version unchanged: $ETCD_CHART_VERSION_BEFORE"


### PR DESCRIPTION
This pull request introduces support for managing multiple etcd Helm chart versions (v6 and v8) in the Milvus Operator, ensuring smooth upgrades and backward compatibility for existing clusters. The changes include logic to detect and persist the correct chart version, documentation updates to guide users, and comprehensive tests to validate behavior.

**Etcd chart versioning support:**

* Added support for both `etcd-v6` (chart 6.3.3) and `etcd-v8` (chart 8.12.0), with logic to detect and set the correct chart version for new and existing deployments. Default is now `etcd-v8` for new clusters. (`apis/milvus.io/v1beta1/dependencies_types.go`, `apis/milvus.io/v1beta1/milvus_webhook.go`, `pkg/controllers/dependencies.go`, `pkg/helm/values/values.go`) 
* Implemented the `ensureEtcdChartVersion` method to detect the chart version from the existing Helm release (using semantic version parsing), or default to v8 if not present, and persist this to the custom resource. (`pkg/controllers/dependencies.go`, `pkg/helm/helm.go`, `pkg/helm/interface.go`) 

**Helm chart selection and asset management:**

* Updated the logic for chart selection to use the correct directory based on chart version, and modified the `Makefile` to download and extract both etcd chart versions. (`pkg/helm/helm.go`, `Makefile`, `pkg/helm/values/values.go`) 
* Added tests to verify chart selection for both etcd versions. (`pkg/helm/helm_test.go`)

**Documentation and test improvements:**

* Documented the breaking changes between etcd chart v6 and v8, including RBAC configuration differences, and provided upgrade guidance. (`docs/administration/manage-dependencies/meta-storage.md`)
* Enhanced unit and upgrade tests to validate chart version detection, persistence, and that values changes do not alter the chart version. (`pkg/controllers/dependencies_test.go`, `test/upgrade.sh`) 

**Webhook and test updates:**

* Updated webhook and test code to set and validate the default chart version for etcd in various scenarios. (`apis/milvus.io/v1beta1/milvus_webhook_test.go`)

These changes ensure that Milvus Operator can handle both legacy and new etcd deployments safely and transparently, improving upgrade reliability and user experience.