### PR TITLE
fix hpa scale action on bootstap condition

### DIFF
--- a/pkg/controllers/deploy_ctrl_util.go
+++ b/pkg/controllers/deploy_ctrl_util.go
@@ -372,6 +372,11 @@ func (c *DeployControllerBizUtilImpl) planScaleForHPA(ctx context.Context, mc v1
 	currentDeployReplicas := getDeployReplicas(currentDeployment)
 	lastDeployReplicas := getDeployReplicas(lastDeployment)
 
+	// On initial bootstrap current and last deployment both have 0 replicas.
+	if currentDeployReplicas == 0 && lastDeployReplicas == 0 {
+		return scaleAction{deploy: currentDeployment, replicaChange: 1}
+	}
+
 	// Bootstrap current deployment to set it to the last deployment's replicas.
 	// should keep trying, if not reach the target number.
 	if int32(currentDeployReplicas) < int32(lastDeployReplicas) {

--- a/pkg/controllers/deploy_ctrl_util_test.go
+++ b/pkg/controllers/deploy_ctrl_util_test.go
@@ -659,6 +659,22 @@ func TestDeployControllerBizUtilImpl_ScaleDeployements(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("hpa bootstrap from 0 replicas scales current to 1", func(t *testing.T) {
+		mockCtrl.Finish()
+		mc := *milvus.DeepCopy()
+		mc.Spec.Com.DataNode.Replicas = int32Ptr(-1)
+		currentDeploy := deployTemplate.DeepCopy()
+		v1beta1.Labels().SetGroupIDStr(DataNodeName, currentDeploy.Labels, "1")
+		currentDeploy.Spec.Replicas = int32Ptr(0)
+		lastDeploy := deployTemplate.DeepCopy()
+		lastDeploy.Spec.Replicas = int32Ptr(0)
+		mockutil.EXPECT().MarkMilvusComponentGroupId(ctx, mc, DataNode, 1).Return(nil)
+		mockutil.EXPECT().UpdateAndRequeue(ctx, currentDeploy).Return(ErrRequeue)
+		err := bizUtil.ScaleDeployments(ctx, mc, currentDeploy, lastDeploy)
+		assert.True(t, errors.Is(err, ErrRequeue))
+		assert.Equal(t, int32(1), *currentDeploy.Spec.Replicas)
+	})
+
 	v1beta1.Labels().SetComponentRolling(&milvus, DataNodeName, true)
 	t.Run("last deploy scale in", func(t *testing.T) {
 		mockCtrl.Finish()


### PR DESCRIPTION
This is a follow up on the PR fix that was done to scale down old deployment with the hpa.   https://github.com/zilliztech/milvus-operator/pull/458   

However i found that this same path is responsible for also bootstrapping the initial deployments. i.e. when last and current deployments are both zero. 