### PR TITLE
fix: set CRD conversion strategy to None when enableWebhook=false

### DIFF
--- a/charts/milvus-operator/templates/crds.yaml
+++ b/charts/milvus-operator/templates/crds.yaml
@@ -9719,10 +9719,13 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.enableWebhook }}
     cert-manager.io/inject-ca-from: '{{.Release.Namespace}}/{{. | include "chart.fullname"}}-serving-cert'
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.2
   name: milvuses.milvus.io
 spec:
+  {{- if .Values.enableWebhook }}
   conversion:
     strategy: Webhook
     webhook:
@@ -9733,6 +9736,10 @@ spec:
           path: /convert
       conversionReviewVersions:
       - v1
+  {{- else }}
+  conversion:
+    strategy: None
+  {{- end }}
   group: milvus.io
   names:
     kind: Milvus


### PR DESCRIPTION
## Summary

Fixes the root cause of [#487](https://github.com/zilliztech/milvus-operator/issues/487) (follow-up to #488).

When `enableWebhook=false`, the Milvus CRD still had `spec.conversion.strategy: Webhook`, causing the apiserver to repeatedly attempt conversion webhook calls that always fail with `connection refused`. This generates excessive error logs and can degrade apiserver performance for other workloads.

Changes:
- Conditionally set CRD conversion strategy: `Webhook` when enabled, `None` when disabled
- Conditionally include `cert-manager.io/inject-ca-from` annotation only when webhook is enabled

### Workaround for existing deployments

Users on older versions can patch the CRD directly without upgrading:

```bash
kubectl patch crd milvuses.milvus.io --type='json' -p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]'
```

## Test plan

- [x] `helm template --set enableWebhook=false`: conversion strategy is `None`, no cert-manager annotation
- [x] `helm template --set enableWebhook=true`: conversion strategy is `Webhook` with full config, cert-manager annotation present