### PR TITLE
fix: preserve CDC deployments during cluster-to-standalone transition

### DIFF
--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -159,6 +159,16 @@ func GetComponentsBySpec(spec v1beta1.MilvusSpec) []MilvusComponent {
 	return ret
 }
 
+// containsComponent reports whether components contains a component with the given name.
+func containsComponent(components []MilvusComponent, name string) bool {
+	for _, c := range components {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // IsCoord return if it's a coord by its name
 func (c MilvusComponent) IsCoord() bool {
 	if c.Name == MixCoordName {

--- a/pkg/controllers/deployment_cluster_to_standalone.go
+++ b/pkg/controllers/deployment_cluster_to_standalone.go
@@ -18,77 +18,50 @@ func (r *MilvusReconciler) CleanupDeploymentClusterToStandalone(ctx context.Cont
 	if mc.Spec.Mode != v1beta1.MilvusModeStandalone || mc.Spec.Com.EnableManualMode {
 		return nil
 	}
-	// If mode is standalone, we need to ensure all other component deployments are scaled down
 
-	// List all deployments with the instance label
 	deploymentList := &appsv1.DeploymentList{}
-	opts := &client.ListOptions{
+	if err := r.List(ctx, deploymentList, &client.ListOptions{
 		Namespace:     mc.Namespace,
 		LabelSelector: labels.SelectorFromSet(NewAppLabels(mc.Name)),
-	}
-
-	if err := r.List(ctx, deploymentList, opts); err != nil {
+	}); err != nil {
 		return pkgerr.Wrap(err, "list deployments by instance label")
 	}
-	var nonStandaloneDeployments []appsv1.Deployment
-	for i := range deploymentList.Items {
-		deployment := &deploymentList.Items[i]
 
-		// Skip the standalone deployments by checking the component label
-		if deployment.Labels != nil && deployment.Labels[AppLabelComponent] == MilvusStandalone.Name {
-			continue
-		}
-		nonStandaloneDeployments = append(nonStandaloneDeployments, *deployment)
-	}
-	if len(nonStandaloneDeployments) == 0 {
-		// No non-standalone deployments found
-		return nil
-	}
-	logger.Info("Found non-standalone deployments to delete, checking standalone deployment readiness")
+	expectedComponents := GetComponentsBySpec(mc.Spec)
 
-	// Check if standalone deployment exists and is ready
-	// Standalone may use 2 deployment mode, so list all standalone deployments
-	standaloneDeploymentList := &appsv1.DeploymentList{}
-	standaloneOpts := &client.ListOptions{
-		Namespace: mc.Namespace,
-		LabelSelector: labels.SelectorFromSet(NewComponentAppLabels(
-			mc.Name,
-			MilvusStandalone.Name,
-		)),
-	}
+	// Partition into expected (check readiness) and unexpected (to delete).
+	// foundComponents ensures all expected components are provisioned before we delete anything.
+	var toDelete []appsv1.Deployment
+	foundComponents := make(map[string]bool)
+	allExpectedReady := true
 
-	if err := r.List(ctx, standaloneDeploymentList, standaloneOpts); err != nil {
-		return pkgerr.Wrap(err, "list standalone deployments")
-	}
-
-	if len(standaloneDeploymentList.Items) == 0 {
-		// If standalone deployment doesn't exist yet, we can't proceed
-		logger.V(1).Info("Standalone deployment not found, skip cluster to standalone cleanup")
-		return nil
-	}
-
-	// Check if all standalone deployments are ready
-	allStandaloneReady := true
-	for i := range standaloneDeploymentList.Items {
-		if !DeploymentReady(standaloneDeploymentList.Items[i].Status) {
-			allStandaloneReady = false
-			break
+	for _, d := range deploymentList.Items {
+		label := d.Labels[AppLabelComponent]
+		if containsComponent(expectedComponents, label) {
+			foundComponents[label] = true
+			if !DeploymentReady(d.Status) {
+				allExpectedReady = false
+			}
+		} else {
+			toDelete = append(toDelete, d)
 		}
 	}
 
-	if !allStandaloneReady {
-		logger.V(1).Info("Standalone deployment not ready yet, skip cluster to standalone cleanup")
+	if len(toDelete) == 0 {
 		return nil
 	}
 
-	logger.Info("Standalone deployment is ready, delete cluster component deployments")
-	for i := range nonStandaloneDeployments {
-		deployment := &nonStandaloneDeployments[i]
-		err := r.Delete(ctx, deployment)
-		if client.IgnoreNotFound(err) != nil {
-			return pkgerr.Wrapf(err, "delete deployment %s/%s", deployment.Namespace, deployment.Name)
+	if len(foundComponents) < len(expectedComponents) || !allExpectedReady {
+		logger.V(1).Info("Expected deployments not all found or ready, skip cluster to standalone cleanup")
+		return nil
+	}
+
+	logger.Info("Expected deployments ready, delete cluster component deployments")
+	for _, d := range toDelete {
+		if err := r.Delete(ctx, &d); client.IgnoreNotFound(err) != nil {
+			return pkgerr.Wrapf(err, "delete deployment %s/%s", d.Namespace, d.Name)
 		}
-		logger.Info("Deleted deployment", "deployment", deployment.Name)
+		logger.Info("Deleted deployment", "deployment", d.Name)
 	}
 
 	return nil

--- a/pkg/controllers/deployment_cluster_to_standalone_test.go
+++ b/pkg/controllers/deployment_cluster_to_standalone_test.go
@@ -95,11 +95,6 @@ func TestMilvusReconciler_ReconcileDeploymentClusterToStandalone(t *testing.T) {
 				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
 			}))
 
-		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
-			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, false, nil),
-			}))
-
 		err := r.CleanupDeploymentClusterToStandalone(ctx, *mc)
 		assert.NoError(t, err)
 	})
@@ -110,14 +105,9 @@ func TestMilvusReconciler_ReconcileDeploymentClusterToStandalone(t *testing.T) {
 
 		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
 			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, false, nil),
+				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
 				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
 				newDeployment("mc-milvus-datanode", DataNode.Name, false, int32Ptr(2)),
-			}))
-
-		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
-			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
 			}))
 
 		deletedDeployments := make(map[string]bool)
@@ -143,9 +133,6 @@ func TestMilvusReconciler_ReconcileDeploymentClusterToStandalone(t *testing.T) {
 				newDeployment("mc-milvus-proxy", Proxy.Name, false, nil),
 			}))
 
-		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
-			DoAndReturn(mockListDeployments([]appsv1.Deployment{}))
-
 		err := r.CleanupDeploymentClusterToStandalone(ctx, *mc)
 		assert.NoError(t, err)
 	})
@@ -156,15 +143,9 @@ func TestMilvusReconciler_ReconcileDeploymentClusterToStandalone(t *testing.T) {
 
 		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
 			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone-0", MilvusStandalone.Name, false, nil),
-				newDeployment("mc-milvus-standalone-1", MilvusStandalone.Name, false, nil),
-				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
-			}))
-
-		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
-			DoAndReturn(mockListDeployments([]appsv1.Deployment{
 				newDeployment("mc-milvus-standalone-0", MilvusStandalone.Name, true, nil),
 				newDeployment("mc-milvus-standalone-1", MilvusStandalone.Name, true, nil),
+				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
 			}))
 
 		mockClient.EXPECT().Delete(gomock.Any(), gomock.Any()).
@@ -178,22 +159,73 @@ func TestMilvusReconciler_ReconcileDeploymentClusterToStandalone(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("standalone mode - 2 deployment mode with one not ready should skip", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Mode = v1beta1.MilvusModeStandalone
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
+			DoAndReturn(mockListDeployments([]appsv1.Deployment{
+				newDeployment("mc-milvus-standalone-0", MilvusStandalone.Name, true, nil),
+				newDeployment("mc-milvus-standalone-1", MilvusStandalone.Name, false, nil),
+				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
+			}))
+
+		err := r.CleanupDeploymentClusterToStandalone(ctx, *mc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("standalone with cdc - cdc deployment should not be deleted", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Mode = v1beta1.MilvusModeStandalone
+		mc.Spec.Com.Cdc = &v1beta1.MilvusCdc{}
+		mc.Spec.Com.Cdc.Replicas = int32Ptr(1)
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
+			DoAndReturn(mockListDeployments([]appsv1.Deployment{
+				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
+				newDeployment("mc-milvus-cdc", Cdc.Name, true, nil),
+				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
+			}))
+
+		mockClient.EXPECT().Delete(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx interface{}, obj interface{}, opts ...interface{}) error {
+				deploy := obj.(*appsv1.Deployment)
+				assert.Equal(t, "mc-milvus-proxy", deploy.Name)
+				return nil
+			})
+
+		err := r.CleanupDeploymentClusterToStandalone(ctx, *mc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("standalone with cdc - cdc not ready should skip cleanup", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Mode = v1beta1.MilvusModeStandalone
+		mc.Spec.Com.Cdc = &v1beta1.MilvusCdc{}
+		mc.Spec.Com.Cdc.Replicas = int32Ptr(1)
+
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
+			DoAndReturn(mockListDeployments([]appsv1.Deployment{
+				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
+				newDeployment("mc-milvus-cdc", Cdc.Name, false, nil),
+				newDeployment("mc-milvus-proxy", Proxy.Name, false, int32Ptr(1)),
+			}))
+
+		err := r.CleanupDeploymentClusterToStandalone(ctx, *mc)
+		assert.NoError(t, err)
+	})
+
 	t.Run("standalone mode - multiple deployments of same component should all be deleted", func(t *testing.T) {
 		mc := env.Inst.DeepCopy()
 		mc.Spec.Mode = v1beta1.MilvusModeStandalone
 
 		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
 			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, false, nil),
+				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
 				newDeployment("mc-milvus-querynode-0", QueryNode.Name, false, int32Ptr(1)),
 				newDeployment("mc-milvus-querynode-1", QueryNode.Name, false, int32Ptr(1)),
 				newDeployment("mc-milvus-datanode-0", DataNode.Name, false, int32Ptr(2)),
 				newDeployment("mc-milvus-datanode-1", DataNode.Name, false, int32Ptr(2)),
-			}))
-
-		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
-			DoAndReturn(mockListDeployments([]appsv1.Deployment{
-				newDeployment("mc-milvus-standalone", MilvusStandalone.Name, true, nil),
 			}))
 
 		deletedDeployments := make(map[string]bool)

--- a/test/min-mc-feature.yaml
+++ b/test/min-mc-feature.yaml
@@ -52,7 +52,9 @@ spec:
         periodSeconds: 10
         successThreshold: 1
     rollingMode: 3
-    enableRollingUpdate: false 
+    enableRollingUpdate: false
+    cdc:
+      replicas: 1
     runWithSubProcess: true
     runAsNonRoot: true
     dummyImage: 'my-registry/my-dummy-image'

--- a/test/min-milvus-feature.yaml
+++ b/test/min-milvus-feature.yaml
@@ -43,6 +43,8 @@ spec:
         successThreshold: 1
     rollingMode: 3
     runWithSubProcess: true
+    cdc:
+      replicas: 1
     dummyImage: 'my-registry/my-dummy-image'
     standalone:
       ingress:


### PR DESCRIPTION
This pull request refactors and improves the logic for cleaning up deployments when transitioning from cluster to standalone mode in the Milvus operator. The main focus is to ensure that only unexpected (non-standalone) components are deleted, and that cleanup only happens when all expected standalone components are present and ready. The changes also add and update tests to cover these scenarios, and update test configurations to include the CDC component.

**Controller logic improvements:**

* Refactored `CleanupDeploymentClusterToStandalone` to:
  - Partition deployments into expected and unexpected components using the new `containsComponent` helper.
  - Only delete unexpected deployments after confirming all expected components are present and ready.
  - Support scenarios where multiple deployments exist for the same component, and handle CDC deployments appropriately. [[1]](diffhunk://#diff-29eccced90dedef6ce55e4436aaa3573710d8812fcf76ff7f19eed22d8d50e46L21-R64) [[2]](diffhunk://#diff-cf22e03585f659ea1cf6df697d8ef018da163a3f20ff6a3d0187c407c151d780R162-R171)

**Testing enhancements:**

* Added and updated test cases in `deployment_cluster_to_standalone_test.go` to:
  - Cover scenarios with multiple standalone deployments, readiness checks, and the presence of CDC components.
  - Ensure CDC deployments are not deleted if specified and only cleaned up when ready.
  - Remove redundant mock expectations and streamline test logic. [[1]](diffhunk://#diff-a49dad621795721b5b67605786f10e56031b5a68fedc7dec21a7a0225f6e2549L98-L102) [[2]](diffhunk://#diff-a49dad621795721b5b67605786f10e56031b5a68fedc7dec21a7a0225f6e2549L113-L122) [[3]](diffhunk://#diff-a49dad621795721b5b67605786f10e56031b5a68fedc7dec21a7a0225f6e2549R136-R187) [[4]](diffhunk://#diff-a49dad621795721b5b67605786f10e56031b5a68fedc7dec21a7a0225f6e2549L181-R228)

**Test configuration updates:**

* Updated test feature YAML files to include CDC component configuration for more comprehensive testing. [[1]](diffhunk://#diff-6c8a904fcdebf6e205d6a7f568399d24a1fd7871b615980a0a2913e565b9d9c1R56-R57) [[2]](diffhunk://#diff-6a67b01ecbdac926160611ed55ef5646e6615c9cee5d4d586bea0daeea90ec95R46-R47)