### PR TITLE
fix: skip PVC reconciliation when StatefulSet does not exist yet

### DIFF
--- a/pkg/controllers/dependencies.go
+++ b/pkg/controllers/dependencies.go
@@ -283,6 +283,10 @@ func (l *LocalHelmReconciler) reconcilePVCs(ctx context.Context, namespace, rele
 			key := client.ObjectKey{Name: saveName, Namespace: namespace}
 			err = k8sUtil.GetSavedObject(ctx, key, savedSts)
 			if err != nil {
+				if kerrors.IsNotFound(err) {
+					logger.Info("StatefulSet not found and no saved StatefulSet to restore, skipping PVC reconciliation", "saveName", saveName)
+					return nil
+				}
 				return fmt.Errorf("failed to get saved StatefulSet: %v", err)
 			}
 

--- a/pkg/controllers/dependencies_test.go
+++ b/pkg/controllers/dependencies_test.go
@@ -239,14 +239,38 @@ func TestLocalHelmReconciler_reconcilePVCs(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("error getting statefulset", func(t *testing.T) {
+	t.Run("sts not found and no saved object, skip reconciliation", func(t *testing.T) {
 		fakeClientset := fakekubernetes.NewSimpleClientset()
 		rec.clientset = fakeClientset
 
 		mc := v1beta1.Milvus{}
 		mc.Default()
 
+		// STS not found, saved ControllerRevision also not found → should skip (return nil)
 		err = rec.reconcilePVCs(ctx, "test-namespace", "non-existent", "5Gi", "10Gi", mc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("sts not found, saved object get error (non-NotFound)", func(t *testing.T) {
+		fakeClientset := fakekubernetes.NewSimpleClientset()
+		rec.clientset = fakeClientset
+
+		// Insert a ControllerRevision with malformed data to trigger unmarshal error in GetSavedObject
+		cr := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-sts-old-sts",
+				Namespace: "test-namespace",
+			},
+			Data: runtime.RawExtension{Raw: []byte("not-valid-yaml{{{")},
+		}
+		err = fakeClient.Create(ctx, cr)
+		assert.NoError(t, err)
+		defer fakeClient.Delete(ctx, cr) //nolint:errcheck
+
+		mc := v1beta1.Milvus{}
+		mc.Default()
+
+		err = rec.reconcilePVCs(ctx, "test-namespace", "bad-sts", "5Gi", "10Gi", mc)
 		assert.Error(t, err)
 	})
 
@@ -280,7 +304,8 @@ func TestLocalHelmReconciler_reconcilePVCs(t *testing.T) {
 		mc := v1beta1.Milvus{}
 		mc.Default()
 
-		err = rec.reconcilePVCs(ctx, "test-namespace", "test-etcd", "invalid", "10Gi", mc)
+		// newSize is unparseable → should fail at resource.ParseQuantity before touching the STS
+		err = rec.reconcilePVCs(ctx, "test-namespace", "test-etcd", "5Gi", "invalid", mc)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
Background: 

* If a deploy fails before the StatefulSet is created, reconcilePVCs would error out trying to fetch a saved object that also doesn't exist. Handle this case by returning nil early so the reconcile loop can retry without noise.

Behavior improvements:

* The `reconcilePVCs` function now logs and skips PVC reconciliation (returns nil) if neither the StatefulSet nor a saved StatefulSet exists, instead of returning an error.

Test coverage improvements:

* The test `TestLocalHelmReconciler_reconcilePVCs` adds a case to verify that missing both the StatefulSet and its saved object results in a successful (nil) return, not an error.
* A new test case is added to ensure that if retrieving the saved object fails with an error other than NotFound (e.g., due to malformed data), the error is properly returned.
* The test for an invalid PVC size is clarified to ensure it fails at the quantity parsing stage before attempting to access the StatefulSet.