### PR TITLE
fix: preserve resources on orphan milvus delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           make go-generate
           make test-only
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/pkg/controllers/milvus_controller.go
+++ b/pkg/controllers/milvus_controller.go
@@ -39,10 +39,9 @@ import (
 )
 
 const (
-	MilvusFinalizerName         = "milvus.milvus.io/finalizer"
-	ForegroundDeletionFinalizer = "foregroundDeletion"
-	PauseReconcileAnnotation    = "milvus.io/pause-reconcile"
-	MaintainingAnnotation       = "milvus.io/maintaining"
+	MilvusFinalizerName      = "milvus.milvus.io/finalizer"
+	PauseReconcileAnnotation = "milvus.io/pause-reconcile"
+	MaintainingAnnotation    = "milvus.io/maintaining"
 )
 
 // MilvusReconciler reconciles a Milvus object
@@ -117,12 +116,23 @@ func (r *MilvusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 		}
 
+		if controllerutil.ContainsFinalizer(milvus, metav1.FinalizerOrphanDependents) {
+			logger.Info("orphan deleting milvus: skip foreground deletion and cleanup")
+			if controllerutil.ContainsFinalizer(milvus, MilvusFinalizerName) {
+				milvusStatusCollector.DeleteLabelValues(milvus.Namespace, milvus.Name)
+				controllerutil.RemoveFinalizer(milvus, MilvusFinalizerName)
+				err := r.Update(ctx, milvus)
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
 		stopped, err := CheckMilvusStopped(ctx, r.Client, *milvus)
 		if !stopped || err != nil {
 			if err != nil {
 				logger.Error(err, "deleting milvus: check milvus stopped failed")
 			} else {
-				if !controllerutil.ContainsFinalizer(milvus, ForegroundDeletionFinalizer) {
+				if !controllerutil.ContainsFinalizer(milvus, metav1.FinalizerDeleteDependents) {
 					// delete self again with foreground deletion
 					logger.Info("change background delete to foreground")
 					if err := r.Delete(ctx, milvus, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {

--- a/pkg/controllers/milvus_controller_test.go
+++ b/pkg/controllers/milvus_controller_test.go
@@ -20,12 +20,16 @@ import (
 
 var mockCheckMilvusStopRet = false
 var mockCheckMilvusStopErr error = nil
+var mockCheckMilvusStopCalls int
 var mockCheckMilvusStop = func(ctx context.Context, cli client.Client, mc v1beta1.Milvus) (bool, error) {
+	mockCheckMilvusStopCalls++
 	return mockCheckMilvusStopRet, mockCheckMilvusStopErr
 }
 
 var mockFinalizeRet error
+var mockFinalizeCalls int
 var mockFinalize = func(ctx context.Context, r *MilvusReconciler, mc v1beta1.Milvus) error {
+	mockFinalizeCalls++
 	return mockFinalizeRet
 }
 
@@ -110,10 +114,44 @@ func TestClusterReconciler(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("delete orphan keeps resources", func(t *testing.T) {
+		defer ctrl.Finish()
+		mockCheckMilvusStopCalls = 0
+		mockFinalizeCalls = 0
+		mockCheckMilvusStopRet = false
+		mockCheckMilvusStopErr = nil
+		mockFinalizeRet = nil
+		m.Finalizers = []string{metav1.FinalizerOrphanDependents, MilvusFinalizerName}
+		m.Status.Status = ""
+		m.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx, key, obj interface{}, opts ...any) {
+				o := obj.(*v1beta1.Milvus)
+				*o = m
+			}).
+			Return(nil)
+
+		mockClient.EXPECT().Status().Return(mockStatusCli)
+		mockStatusCli.EXPECT().Update(gomock.Any(), gomock.Any()).Times(1)
+
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Do(
+			func(ctx, obj interface{}, opts ...interface{}) {
+				u := obj.(*v1beta1.Milvus)
+				assert.Equal(t, []string{metav1.FinalizerOrphanDependents}, u.Finalizers)
+			},
+		).Return(nil)
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, mockCheckMilvusStopCalls)
+		assert.Equal(t, 0, mockFinalizeCalls)
+	})
+
 	t.Run("delete foreground deletion", func(t *testing.T) {
 		defer ctrl.Finish()
 		mockCheckMilvusStopRet = true
-		m.Finalizers = []string{ForegroundDeletionFinalizer, MilvusFinalizerName}
+		m.Finalizers = []string{metav1.FinalizerDeleteDependents, MilvusFinalizerName}
 		m.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx, key, obj interface{}, opts ...any) {
@@ -129,7 +167,7 @@ func TestClusterReconciler(t *testing.T) {
 			func(ctx, obj interface{}, opts ...interface{}) {
 				// finalizer should be removed
 				u := obj.(*v1beta1.Milvus)
-				assert.Equal(t, []string{ForegroundDeletionFinalizer}, u.Finalizers)
+				assert.Equal(t, []string{metav1.FinalizerDeleteDependents}, u.Finalizers)
 			},
 		).Return(nil)
 
@@ -139,7 +177,7 @@ func TestClusterReconciler(t *testing.T) {
 
 	t.Run("milvus not stopped or check failed", func(t *testing.T) {
 		defer ctrl.Finish()
-		m.Finalizers = []string{ForegroundDeletionFinalizer, MilvusFinalizerName}
+		m.Finalizers = []string{metav1.FinalizerDeleteDependents, MilvusFinalizerName}
 		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx, key, obj interface{}, opts ...any) {
 				o := obj.(*v1beta1.Milvus)


### PR DESCRIPTION
## Summary
- Preserve Milvus resources when the Milvus CR is deleted with orphan propagation.
- Skip converting orphan deletes to foreground deletes.
- Use Kubernetes finalizer constants for orphan/foreground checks.

## Tests
- `go test ./pkg/controllers -run TestClusterReconciler -count=1`
- `go test ./pkg/controllers -count=1`
