### PR TITLE
chore: bump operator to 1.3.7 and helm to 5.0.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 1.3.6
+VERSION ?= 1.3.7
 TOOL_VERSION ?= 1.0.0
-MILVUS_HELM_VERSION ?= milvus-5.0.13
+MILVUS_HELM_VERSION ?= milvus-5.0.22
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)
 TOOL_RELEASE_IMG ?= milvusdb/milvus-config-tool:v$(TOOL_VERSION)
 KIND_CLUSTER ?= kind

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ helm -n milvus-operator upgrade --install --create-namespace milvus-operator mil
 Or with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.6/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.7/deploy/manifests/deployment.yaml
 ```
 
 For more information Check [Installation Instructions](docs/installation/installation.md)
@@ -135,11 +135,11 @@ Use helm:
 ```shell
 helm upgrade --install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.6/milvus-operator-1.3.6.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.7/milvus-operator-1.3.7.tgz
 ```
 
 Or use kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.6/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.7/deploy/manifests/deployment.yaml
 ```

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.6
+version: 1.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.6"
+appVersion: "1.3.7"
 
 dependencies:
   - name: cert-manager

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v1.3.6"
+  tag: "v1.3.7"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-1.3.6
+    helm.sh/chart: milvus-operator-1.3.7
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.6"
+    app.kubernetes.io/version: "1.3.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -9738,20 +9738,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: 'milvus-operator/milvus-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.17.2
   name: milvuses.milvus.io
 spec:
   conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: 'milvus-operator-webhook-service'
-          namespace: milvus-operator
-          path: /convert
-      conversionReviewVersions:
-      - v1
+    strategy: None
   group: milvus.io
   names:
     kind: Milvus
@@ -21039,10 +21030,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-1.3.6
+    helm.sh/chart: milvus-operator-1.3.7
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.6"
+    app.kubernetes.io/version: "1.3.7"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -21055,37 +21046,15 @@ spec:
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
 ---
-# Source: milvus-operator/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    helm.sh/chart: milvus-operator-1.3.6
-    app.kubernetes.io/name: milvus-operator
-    app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.6"
-    app.kubernetes.io/managed-by: Helm
-  name: 'milvus-operator-webhook-service'
-  namespace: "milvus-operator"
-spec:
-  ports:
-  - port: 443
-    targetPort: webhook-server
-    protocol: TCP
-    name: https
-  selector:
-    app.kubernetes.io/name: milvus-operator
-    app.kubernetes.io/instance: milvus-operator
----
 # Source: milvus-operator/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.6
+    helm.sh/chart: milvus-operator-1.3.7
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.6"
+    app.kubernetes.io/version: "1.3.7"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -21116,7 +21085,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v1.3.6'
+        image: 'milvusdb/milvus-operator:v1.3.7'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,7 +12,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.6/milvus-operator-1.3.6.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.7/milvus-operator-1.3.7.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -20,7 +20,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.6/milvus-operator-1.3.6.tgz \
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.7/milvus-operator-1.3.7.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -39,7 +39,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.6/milvus-operator-1.3.6.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.7/milvus-operator-1.3.7.tgz
 ```
 
 ## Delete operator
@@ -62,7 +62,7 @@ If you don't want to use helm you can also install with kubectl and raw manifest
 ## Installation
 It is recommended to install the milvus operator with a newest stable version
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.6/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.7/deploy/manifests/deployment.yaml
 ``` 
 
 Check the installed operators:
@@ -85,7 +85,7 @@ Same as installation, you can update the milvus operator with a newer version by
 Delete the milvus operator stack by the deployment manifest:
 
 ```shell
-kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.6/deploy/manifests/deployment.yaml
+kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.7/deploy/manifests/deployment.yaml
 ```
 
 Or delete the milvus operator stack by using makefile:


### PR DESCRIPTION
## Summary
- Bump Milvus Operator chart/image references to v1.3.7
- Bump bundled milvus-helm to milvus-5.0.22
- Keep the default Milvus version unchanged at v2.6.11 for this release
- Regenerate the deploy manifest and keep enableWebhook=false CRD conversion output aligned with the chart

## Tests
- git diff --check
- GitHub Actions rerun pending
