### PR TITLE
feat: support secretRef for Kafka SASL credentials

### DIFF
--- a/apis/milvus.io/v1beta1/dependencies_types.go
+++ b/apis/milvus.io/v1beta1/dependencies_types.go
@@ -243,6 +243,9 @@ type MilvusKafka struct {
 
 	// +kubebuilder:validation:Optional
 	BrokerList []string `json:"brokerList,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	SecretRef string `json:"secretRef,omitempty"`
 }
 
 // MilvusTei configuration

--- a/apis/milvus.io/v1beta1/label_annotations.go
+++ b/apis/milvus.io/v1beta1/label_annotations.go
@@ -24,6 +24,8 @@ const (
 	StoppedAtAnnotation                    = MilvusIO + "stopped-at"
 	PodAnnotationUsingConfigMap            = MilvusIO + "using-configmap"
 	AnnotationMilvusGeneration             = MilvusIO + "generation"
+	// KafkaSaslCheckSumAnnotation is the checksum of the kafka SASL credentials in use
+	KafkaSaslCheckSumAnnotation = MilvusIO + "kafka-sasl-checksum"
 
 	// PodServiceLabelAddedAnnotation is to indicate whether the milvus.io/service=true label is added to proxy & standalone pods
 	// previously, we use milvus.io/component: proxy / standalone; to select the service pods

--- a/charts/milvus-operator/templates/crds.yaml
+++ b/charts/milvus-operator/templates/crds.yaml
@@ -9381,6 +9381,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:
@@ -10277,6 +10279,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:
@@ -20317,6 +20321,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:

--- a/config/crd/bases/milvus.io_milvusclusters.yaml
+++ b/config/crd/bases/milvus.io_milvusclusters.yaml
@@ -9379,6 +9379,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -533,6 +533,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:
@@ -10573,6 +10575,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -9399,6 +9399,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:
@@ -10287,6 +10289,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:
@@ -20327,6 +20331,8 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
+                      secretRef:
+                        type: string
                     type: object
                   msgStreamType:
                     enum:

--- a/docs/administration/manage-dependencies/message-storage.md
+++ b/docs/administration/manage-dependencies/message-storage.md
@@ -206,6 +206,10 @@ Fields used to configure an external Kafka service include:
 
 - `external`: A `true` value indicates that Milvus uses an external Kafka service.
 - `brokerList`: The list of brokers to send the messages to.
+- `secretRef`: Optional, the name of a Secret storing SASL credentials for the Kafka
+  service, with keys `username` and `password`. When set, it takes precedence over
+  `spec.config.kafka.saslUsername`/`saslPassword`, so SASL credentials don't need to
+  be set as literal values in the Milvus CR.
 
 #### Example
 
@@ -237,6 +241,50 @@ spec:
         - "kafkaBrokerAddr1:9092"
         - "kafkaBrokerAddr2:9092"
         # ...
+```
+
+#### Using a Secret for SASL credentials
+
+Instead of setting `saslUsername`/`saslPassword` as literal values, create a Secret
+holding them:
+
+```yaml
+# # change the <parameters> to match your environment
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-release-kafka-secret
+type: Opaque
+stringData:
+  username: <my-sasl-username>
+  password: <my-sasl-password>
+```
+
+Then reference it via `secretRef`:
+
+```yaml
+apiVersion: milvus.io/v1beta1
+kind: Milvus
+metadata:
+  name: my-release
+  labels:
+    app: milvus
+spec:
+  config:
+    kafka:
+      securityProtocol: SASL_SSL
+      saslMechanisms: PLAIN
+  # Omit other fields ...
+  dependencies:
+    # Omit other fields ...
+    msgStreamType: "kafka"
+    kafka:
+      external: true
+      brokerList:
+        - "kafkaBrokerAddr1:9092"
+        - "kafkaBrokerAddr2:9092"
+        # ...
+      secretRef: "my-release-kafka-secret"
 ```
 
 ### Internal Kafka

--- a/docs/administration/manage-dependencies/message-storage.md
+++ b/docs/administration/manage-dependencies/message-storage.md
@@ -207,9 +207,12 @@ Fields used to configure an external Kafka service include:
 - `external`: A `true` value indicates that Milvus uses an external Kafka service.
 - `brokerList`: The list of brokers to send the messages to.
 - `secretRef`: Optional, the name of a Secret storing SASL credentials for the Kafka
-  service, with keys `username` and `password`. When set, it takes precedence over
-  `spec.config.kafka.saslUsername`/`saslPassword`, so SASL credentials don't need to
-  be set as literal values in the Milvus CR.
+  service. Both the `username` and the `password` key are required; the operator requeues
+  until they are readable instead of writing an unusable Kafka configuration. When set, it
+  takes precedence over `spec.config.kafka.saslUsername`/`saslPassword`, so SASL
+  credentials don't need to be set as literal values in the Milvus CR.
+  The Secret is watched: rotating the credentials in place re-renders the configmap and
+  rolls the Milvus components so that they pick the new credentials up.
 
 #### Example
 

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -465,6 +465,16 @@ func (c MilvusComponent) IsImageUpdated(m *v1beta1.Milvus) bool {
 
 // GetConfCheckSum returns the checksum of the component configuration
 func GetConfCheckSum(spec v1beta1.MilvusSpec) string {
+	return getConfCheckSum(spec, nil)
+}
+
+// GetConfCheckSumWithRefs returns the checksum of the component configuration, including
+// the credentials read from referenced secrets
+func GetConfCheckSumWithRefs(m *v1beta1.Milvus) string {
+	return getConfCheckSum(m.Spec, m.GetAnnotations())
+}
+
+func getConfCheckSum(spec v1beta1.MilvusSpec, annotations map[string]string) string {
 	conf := map[string]interface{}{}
 	conf["conf"] = spec.Conf.Data
 	conf["etcd-endpoints"] = spec.Dep.Etcd.Endpoints
@@ -474,6 +484,13 @@ func GetConfCheckSum(spec v1beta1.MilvusSpec) string {
 	if spec.Dep.WoodPecker.External {
 		conf["woodpecker-external"] = spec.Dep.WoodPecker.External
 		conf["woodpecker-quorumBufferPools"] = spec.Dep.WoodPecker.QuorumBufferPools
+	}
+	// only set when used, to keep the checksum of other instances unchanged
+	if spec.Dep.Kafka.SecretRef != "" {
+		conf["kafka-secretRef"] = spec.Dep.Kafka.SecretRef
+	}
+	if sum := annotations[v1beta1.KafkaSaslCheckSumAnnotation]; sum != "" {
+		conf["kafka-sasl-checksum"] = sum
 	}
 
 	b, err := json.Marshal(conf)

--- a/pkg/controllers/configmaps.go
+++ b/pkg/controllers/configmaps.go
@@ -37,13 +37,13 @@ func (r *MilvusReconciler) getMinioAccessInfo(ctx context.Context, mc v1beta1.Mi
 
 // getKafkaSaslInfo reads the kafka SASL credentials from the referenced secret.
 // Both the username & the password key are required.
-func (r *MilvusReconciler) getKafkaSaslInfo(ctx context.Context, mc v1beta1.Milvus) (string, string, error) {
+func getKafkaSaslInfo(ctx context.Context, cli client.Client, mc v1beta1.Milvus) (string, string, error) {
 	if mc.Spec.Dep.Kafka.SecretRef == "" {
 		return "", "", nil
 	}
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: mc.Namespace, Name: mc.Spec.Dep.Kafka.SecretRef}
-	if err := r.Get(ctx, key, secret); err != nil {
+	if err := cli.Get(ctx, key, secret); err != nil {
 		return "", "", errors.Wrapf(err, "get kafka sasl secret[%s]", key)
 	}
 	username, password := secret.Data[KafkaSaslUsernameKey], secret.Data[KafkaSaslPasswordKey]
@@ -64,7 +64,7 @@ func (r *MilvusReconciler) SyncKafkaSaslCheckSum(ctx context.Context, mc *v1beta
 	newCheckSum := ""
 	if mc.Spec.Dep.MsgStreamType == v1beta1.MsgStreamTypeKafka &&
 		mc.Spec.Dep.Kafka.SecretRef != "" {
-		username, password, err := r.getKafkaSaslInfo(ctx, *mc)
+		username, password, err := getKafkaSaslInfo(ctx, r.Client, *mc)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvu
 	case v1beta1.MsgStreamTypeKafka:
 		util.SetStringSlice(conf, mc.Spec.Dep.Kafka.BrokerList, "kafka", "brokerList")
 		if mc.Spec.Dep.Kafka.SecretRef != "" {
-			username, password, err := r.getKafkaSaslInfo(ctx, mc)
+			username, password, err := getKafkaSaslInfo(ctx, r.Client, mc)
 			if err != nil {
 				return err
 			}

--- a/pkg/controllers/configmaps.go
+++ b/pkg/controllers/configmaps.go
@@ -35,18 +35,56 @@ func (r *MilvusReconciler) getMinioAccessInfo(ctx context.Context, mc v1beta1.Mi
 
 }
 
-func (r *MilvusReconciler) getKafkaSaslInfo(ctx context.Context, mc v1beta1.Milvus) (string, string) {
+// getKafkaSaslInfo reads the kafka SASL credentials from the referenced secret.
+// Both the username & the password key are required.
+func (r *MilvusReconciler) getKafkaSaslInfo(ctx context.Context, mc v1beta1.Milvus) (string, string, error) {
 	if mc.Spec.Dep.Kafka.SecretRef == "" {
-		return "", ""
+		return "", "", nil
 	}
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: mc.Namespace, Name: mc.Spec.Dep.Kafka.SecretRef}
 	if err := r.Get(ctx, key, secret); err != nil {
-		r.logger.Error(err, "get kafka sasl secret error")
-		return "", ""
+		return "", "", errors.Wrapf(err, "get kafka sasl secret[%s]", key)
+	}
+	username, password := secret.Data[KafkaSaslUsernameKey], secret.Data[KafkaSaslPasswordKey]
+	if len(username) == 0 {
+		return "", "", errors.Errorf("kafka sasl secret[%s] has no [%s] key", key, KafkaSaslUsernameKey)
+	}
+	if len(password) == 0 {
+		return "", "", errors.Errorf("kafka sasl secret[%s] has no [%s] key", key, KafkaSaslPasswordKey)
 	}
 
-	return string(secret.Data[KafkaSaslUsernameKey]), string(secret.Data[KafkaSaslPasswordKey])
+	return string(username), string(password), nil
+}
+
+// SyncKafkaSaslCheckSum records the checksum of the kafka SASL credentials in an annotation
+// on the milvus object, so that rotating them rolls the components.
+func (r *MilvusReconciler) SyncKafkaSaslCheckSum(ctx context.Context, mc *v1beta1.Milvus) error {
+	oldCheckSum := mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation]
+	newCheckSum := ""
+	if mc.Spec.Dep.MsgStreamType == v1beta1.MsgStreamTypeKafka &&
+		mc.Spec.Dep.Kafka.SecretRef != "" {
+		username, password, err := r.getKafkaSaslInfo(ctx, *mc)
+		if err != nil {
+			return err
+		}
+		newCheckSum = util.CheckSum([]byte(username + ":" + password))
+	}
+	if oldCheckSum == newCheckSum {
+		return nil
+	}
+
+	if newCheckSum == "" {
+		delete(mc.Annotations, v1beta1.KafkaSaslCheckSumAnnotation)
+	} else {
+		if mc.Annotations == nil {
+			mc.Annotations = map[string]string{}
+		}
+		mc.Annotations[v1beta1.KafkaSaslCheckSumAnnotation] = newCheckSum
+	}
+	r.logger.Info("kafka sasl credentials changed, update checksum annotation",
+		"namespace", mc.Namespace, "name", mc.Name)
+	return errors.Wrap(r.Update(ctx, mc), "update kafka sasl checksum annotation")
 }
 
 func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvus, configmap *corev1.ConfigMap) error {
@@ -75,7 +113,11 @@ func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvu
 	switch mc.Spec.Dep.MsgStreamType {
 	case v1beta1.MsgStreamTypeKafka:
 		util.SetStringSlice(conf, mc.Spec.Dep.Kafka.BrokerList, "kafka", "brokerList")
-		if username, password := r.getKafkaSaslInfo(ctx, mc); mc.Spec.Dep.Kafka.SecretRef != "" {
+		if mc.Spec.Dep.Kafka.SecretRef != "" {
+			username, password, err := r.getKafkaSaslInfo(ctx, mc)
+			if err != nil {
+				return err
+			}
 			util.SetValue(conf, username, "kafka", "saslUsername")
 			util.SetValue(conf, password, "kafka", "saslPassword")
 		}

--- a/pkg/controllers/configmaps.go
+++ b/pkg/controllers/configmaps.go
@@ -35,6 +35,20 @@ func (r *MilvusReconciler) getMinioAccessInfo(ctx context.Context, mc v1beta1.Mi
 
 }
 
+func (r *MilvusReconciler) getKafkaSaslInfo(ctx context.Context, mc v1beta1.Milvus) (string, string) {
+	if mc.Spec.Dep.Kafka.SecretRef == "" {
+		return "", ""
+	}
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: mc.Namespace, Name: mc.Spec.Dep.Kafka.SecretRef}
+	if err := r.Get(ctx, key, secret); err != nil {
+		r.logger.Error(err, "get kafka sasl secret error")
+		return "", ""
+	}
+
+	return string(secret.Data[KafkaSaslUsernameKey]), string(secret.Data[KafkaSaslPasswordKey])
+}
+
 func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvus, configmap *corev1.ConfigMap) error {
 	confYaml, err := util.GetTemplatedValues(config.GetMilvusConfigTemplate(), mc)
 	if err != nil {
@@ -61,6 +75,10 @@ func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvu
 	switch mc.Spec.Dep.MsgStreamType {
 	case v1beta1.MsgStreamTypeKafka:
 		util.SetStringSlice(conf, mc.Spec.Dep.Kafka.BrokerList, "kafka", "brokerList")
+		if username, password := r.getKafkaSaslInfo(ctx, mc); mc.Spec.Dep.Kafka.SecretRef != "" {
+			util.SetValue(conf, username, "kafka", "saslUsername")
+			util.SetValue(conf, password, "kafka", "saslPassword")
+		}
 		// delete other mq config to make milvus use kafka
 		delete(conf, "pulsar")
 		delete(conf, "rocksmq")

--- a/pkg/controllers/configmaps_test.go
+++ b/pkg/controllers/configmaps_test.go
@@ -321,7 +321,7 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		cm := &corev1.ConfigMap{}
 		cm.Namespace = "ns"
 		cm.Name = "cm1"
-		// get secret of minio (NotFound, as in other cases) and the new kafka sasl secret
+		// get the minio secret (NotFound) & the kafka sasl secret
 		mockClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
 			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
@@ -345,5 +345,121 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		kafka := conf["kafka"].(map[string]interface{})
 		assert.Equal(t, "kafka-user", kafka["saslUsername"])
 		assert.Equal(t, "kafka-pass", kafka["saslPassword"])
+	})
+
+	t.Run("kafka sasl secret read failed", func(t *testing.T) {
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		mc.Spec.Conf.Data = nil
+		cm := &corev1.ConfigMap{}
+		cm.Namespace = "ns"
+		cm.Name = "cm1"
+		// the minio secret & the kafka sasl secret are both missing
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")).
+			Times(2)
+
+		err := r.updateConfigMap(ctx, mc, cm)
+		assert.Error(t, err)
+	})
+
+	t.Run("kafka sasl secret missing required key", func(t *testing.T) {
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		mc.Spec.Conf.Data = nil
+		cm := &corev1.ConfigMap{}
+		cm.Namespace = "ns"
+		cm.Name = "cm1"
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
+					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
+				}
+				secret := obj.(*corev1.Secret)
+				secret.Data = map[string][]byte{
+					KafkaSaslUsernameKey: []byte("kafka-user"),
+				}
+				return nil
+			}).
+			Times(2)
+
+		err := r.updateConfigMap(ctx, mc, cm)
+		assert.ErrorContains(t, err, KafkaSaslPasswordKey)
+	})
+}
+
+func TestMilvusReconciler_SyncKafkaSaslCheckSum(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.checkMocks()
+	mockClient := env.MockClient
+	r := env.Reconciler
+	ctx := env.ctx
+
+	expectGetKafkaSecret := func(username, password string) {
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				secret := obj.(*corev1.Secret)
+				secret.Data = map[string][]byte{
+					KafkaSaslUsernameKey: []byte(username),
+					KafkaSaslPasswordKey: []byte(password),
+				}
+				return nil
+			})
+	}
+
+	t.Run("no secretRef, no annotation", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		assert.NotContains(t, mc.GetAnnotations(), v1beta1.KafkaSaslCheckSumAnnotation)
+	})
+
+	t.Run("annotation set from secret", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		expectGetKafkaSecret("kafka-user", "kafka-pass")
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		checkSum := mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation]
+		assert.NotEmpty(t, checkSum)
+
+		// credentials unchanged, no update expected
+		expectGetKafkaSecret("kafka-user", "kafka-pass")
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		assert.Equal(t, checkSum, mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation])
+
+		// credentials rotated, annotation & checksum change
+		expectGetKafkaSecret("kafka-user", "new-pass")
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		rotatedCheckSum := mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation]
+		assert.NotEmpty(t, rotatedCheckSum)
+		assert.NotEqual(t, checkSum, rotatedCheckSum)
+		assert.NotEqual(t, GetConfCheckSum(mc.Spec), GetConfCheckSumWithRefs(mc))
+	})
+
+	t.Run("annotation removed when secretRef unset", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Annotations = map[string]string{v1beta1.KafkaSaslCheckSumAnnotation: "stale"}
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		assert.NotContains(t, mc.GetAnnotations(), v1beta1.KafkaSaslCheckSumAnnotation)
+	})
+
+	t.Run("secret read failed", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr"))
+		assert.Error(t, r.SyncKafkaSaslCheckSum(ctx, mc))
 	})
 }

--- a/pkg/controllers/configmaps_test.go
+++ b/pkg/controllers/configmaps_test.go
@@ -312,4 +312,38 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("kafka sasl secretRef populates saslUsername/saslPassword from secret", func(t *testing.T) {
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		mc.Spec.Conf.Data = nil
+		cm := &corev1.ConfigMap{}
+		cm.Namespace = "ns"
+		cm.Name = "cm1"
+		// get secret of minio (NotFound, as in other cases) and the new kafka sasl secret
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
+					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
+				}
+				secret := obj.(*corev1.Secret)
+				secret.Data = map[string][]byte{
+					KafkaSaslUsernameKey: []byte("kafka-user"),
+					KafkaSaslPasswordKey: []byte("kafka-pass"),
+				}
+				return nil
+			}).
+			Times(2)
+
+		err := r.updateConfigMap(ctx, mc, cm)
+		assert.NoError(t, err)
+
+		conf := map[string]interface{}{}
+		assert.NoError(t, yaml.Unmarshal([]byte(cm.Data[UserYaml]), &conf))
+		kafka := conf["kafka"].(map[string]interface{})
+		assert.Equal(t, "kafka-user", kafka["saslUsername"])
+		assert.Equal(t, "kafka-pass", kafka["saslPassword"])
+	})
 }

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -497,7 +497,7 @@ func GetDeploymentStrategy(milvus *v1beta1.Milvus, component MilvusComponent) ap
 }
 
 func (m milvusDeploymentUpdater) GetConfCheckSum() string {
-	return GetConfCheckSum(m.Spec)
+	return GetConfCheckSumWithRefs(m.GetMilvus())
 }
 
 func (m milvusDeploymentUpdater) GetMergedComponentSpec() ComponentSpec {

--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -30,6 +30,8 @@ const (
 	HookYaml                   = "hook.yaml"
 	AccessKey                  = "accesskey"
 	SecretKey                  = "secretkey"
+	KafkaSaslUsernameKey       = "username"
+	KafkaSaslPasswordKey       = "password"
 	AnnotationCheckSum         = "checksum/config"
 	AnnotationMilvusGeneration = v1beta1.AnnotationMilvusGeneration
 

--- a/pkg/controllers/milvus_controller.go
+++ b/pkg/controllers/milvus_controller.go
@@ -27,10 +27,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -181,6 +183,10 @@ func (r *MilvusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	if err := r.SyncKafkaSaslCheckSum(ctx, milvus); err != nil {
+		return ctrl.Result{}, pkgErr.Wrap(err, "sync kafka sasl checksum")
+	}
+
 	if err := r.ReconcileAll(ctx, *milvus); err != nil {
 		if pkgErr.Is(err, ErrRequeue) {
 			logger.Info("requeue", "err", err.Error())
@@ -223,6 +229,10 @@ func (r *MilvusReconciler) VerifyCR(ctx context.Context, milvus *milvusv1beta1.M
 func (r *MilvusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&milvusv1beta1.Milvus{}).
+		// reconcile when a secret referenced by the milvus spec changes
+		Watches(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSecretToMilvusRequests),
+			ctrlbuilder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		// For(&milvusv1alpha1.MilvusCluster{}).
 		// Owns(&appsv1.Deployment{}).
 		// Owns(&corev1.ConfigMap{}).
@@ -237,6 +247,30 @@ func (r *MilvusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	} */
 
 	return builder.Complete(r)
+}
+
+// mapSecretToMilvusRequests returns the milvus instances that reference the secret
+func (r *MilvusReconciler) mapSecretToMilvusRequests(ctx context.Context, obj client.Object) []ctrl.Request {
+	milvusList := &milvusv1beta1.MilvusList{}
+	if err := r.List(ctx, milvusList, client.InNamespace(obj.GetNamespace())); err != nil {
+		predicateLog.Error(err, "list milvus for secret", "secret", obj.GetName(), "namespace", obj.GetNamespace())
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for i := range milvusList.Items {
+		milvus := &milvusList.Items[i]
+		if !milvusReferencesSecret(milvus, obj.GetName()) {
+			continue
+		}
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(milvus)})
+	}
+	return requests
+}
+
+func milvusReferencesSecret(milvus *milvusv1beta1.Milvus, secretName string) bool {
+	return milvus.Spec.Dep.MsgStreamType == milvusv1beta1.MsgStreamTypeKafka &&
+		milvus.Spec.Dep.Kafka.SecretRef == secretName
 }
 
 var predicateLog = logf.Log.WithName("predicates").WithName("Milvus")

--- a/pkg/controllers/milvus_controller_test.go
+++ b/pkg/controllers/milvus_controller_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -229,5 +231,54 @@ func TestMilvusReconciler_ReconcileLegacyValues(t *testing.T) {
 		err := r.syncLegacyValues(ctx, obj)
 		assert.NoError(t, err)
 		assert.Equal(t, false, obj.LegacyNeedSyncValues())
+	})
+}
+
+func TestMilvusReconciler_mapSecretToMilvusRequests(t *testing.T) {
+	testEnv := newTestEnv(t)
+	defer testEnv.checkMocks()
+	r := testEnv.Reconciler
+	ctx := context.Background()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "kafka-sasl-secret"},
+	}
+
+	newMilvus := func(name, secretRef string, msgStreamType v1beta1.MsgStreamType) v1beta1.Milvus {
+		mc := v1beta1.Milvus{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name},
+		}
+		mc.Default()
+		mc.Spec.Dep.MsgStreamType = msgStreamType
+		mc.Spec.Dep.Kafka.SecretRef = secretRef
+		return mc
+	}
+
+	expectList := func(items ...v1beta1.Milvus) {
+		testEnv.MockClient.EXPECT().
+			List(gomock.Any(), gomock.AssignableToTypeOf(&v1beta1.MilvusList{}), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list.(*v1beta1.MilvusList).Items = items
+				return nil
+			})
+	}
+
+	t.Run("only referencing instances enqueued", func(t *testing.T) {
+		expectList(
+			newMilvus("referencing", "kafka-sasl-secret", v1beta1.MsgStreamTypeKafka),
+			newMilvus("other-secret", "another-secret", v1beta1.MsgStreamTypeKafka),
+			newMilvus("not-kafka", "kafka-sasl-secret", v1beta1.MsgStreamTypePulsar),
+			newMilvus("no-secret", "", v1beta1.MsgStreamTypeKafka),
+		)
+		requests := r.mapSecretToMilvusRequests(ctx, secret)
+		assert.Equal(t, []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "referencing"}},
+		}, requests)
+	})
+
+	t.Run("list failed", func(t *testing.T) {
+		testEnv.MockClient.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).Return(errMock)
+		assert.Nil(t, r.mapSecretToMilvusRequests(ctx, secret))
 	})
 }

--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -420,6 +420,19 @@ func (r *MilvusStatusSyncer) GetMsgStreamCondition(
 				Message: err.Error(),
 			}, nil
 		}
+		// credentials from the referenced secret take precedence over the plaintext config
+		if mc.Spec.Dep.Kafka.SecretRef != "" {
+			username, password, err := getKafkaSaslInfo(ctx, r.Client, mc)
+			if err != nil {
+				return v1beta1.MilvusCondition{
+					Type:    v1beta1.MsgStreamReady,
+					Status:  corev1.ConditionUnknown,
+					Message: err.Error(),
+				}, nil
+			}
+			kafkaConf.SASLUsername = username
+			kafkaConf.SASLPassword = password
+		}
 		kafkaConf.BrokerList = mc.Spec.Dep.Kafka.BrokerList
 		getter = wrapKafkaConditonGetter(ctx, r.logger, mc.Spec.Dep.Kafka, *kafkaConf)
 		eps = mc.Spec.Dep.Kafka.BrokerList

--- a/pkg/controllers/status_cluster_test.go
+++ b/pkg/controllers/status_cluster_test.go
@@ -673,3 +673,88 @@ func TestGetMilvusUpdatedCondition(t *testing.T) {
 		assert.Contains(t, cond.Message, ProxyName)
 	})
 }
+
+func TestMilvusStatusSyncer_GetMsgStreamCondition_KafkaSecretRef(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockCli := NewMockK8sClient(ctrl)
+	ctx := context.Background()
+	s := NewMilvusStatusSyncer(ctx, mockCli, logf.Log.WithName("test"))
+
+	milvus := v1beta1.Milvus{}
+	milvus.Namespace = "ns"
+	milvus.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+	milvus.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+	// plaintext credentials in the config are overridden by the secret
+	milvus.Spec.Conf.Data = map[string]interface{}{
+		"kafka": map[string]interface{}{
+			"securityProtocol": "SASL_SSL",
+			"saslMechanisms":   "PLAIN",
+			"saslUsername":     "plaintext-user",
+			"saslPassword":     "plaintext-pass",
+		},
+	}
+
+	expectGetSecret := func(data map[string][]byte) {
+		mockCli.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				obj.(*corev1.Secret).Data = data
+				return nil
+			})
+	}
+	stubCheckKafkaNotCalled := func() *gostub.Stubs {
+		return gostub.Stub(&checkKafka, func(conf external.CheckKafkaConfig) error {
+			t.Error("kafka should not be probed with unresolved credentials")
+			return nil
+		})
+	}
+
+	t.Run("credentials read from secret", func(t *testing.T) {
+		milvus.Spec.Dep.Kafka.BrokerList = []string{"broker-ok:9092"}
+		var probed external.CheckKafkaConfig
+		stubs := gostub.Stub(&checkKafka, func(conf external.CheckKafkaConfig) error {
+			probed = conf
+			return nil
+		})
+		defer stubs.Reset()
+		expectGetSecret(map[string][]byte{
+			KafkaSaslUsernameKey: []byte("kafka-user"),
+			KafkaSaslPasswordKey: []byte("kafka-pass"),
+		})
+
+		ret, err := s.GetMsgStreamCondition(ctx, milvus)
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionTrue, ret.Status)
+		assert.Equal(t, "kafka-user", probed.SASLUsername)
+		assert.Equal(t, "kafka-pass", probed.SASLPassword)
+		assert.Equal(t, "SASL_SSL", probed.SecurityProtocol)
+		assert.Equal(t, milvus.Spec.Dep.Kafka.BrokerList, probed.BrokerList)
+	})
+
+	t.Run("secret not found", func(t *testing.T) {
+		milvus.Spec.Dep.Kafka.BrokerList = []string{"broker-notfound:9092"}
+		stubs := stubCheckKafkaNotCalled()
+		defer stubs.Reset()
+		mockCli.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			Return(kerrors.NewNotFound(schema.GroupResource{}, "mockErr"))
+
+		ret, err := s.GetMsgStreamCondition(ctx, milvus)
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionUnknown, ret.Status)
+		assert.Contains(t, ret.Message, milvus.Spec.Dep.Kafka.SecretRef)
+	})
+
+	t.Run("secret missing password key", func(t *testing.T) {
+		milvus.Spec.Dep.Kafka.BrokerList = []string{"broker-nokey:9092"}
+		stubs := stubCheckKafkaNotCalled()
+		defer stubs.Reset()
+		expectGetSecret(map[string][]byte{KafkaSaslUsernameKey: []byte("kafka-user")})
+
+		ret, err := s.GetMsgStreamCondition(ctx, milvus)
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionUnknown, ret.Status)
+		assert.Contains(t, ret.Message, KafkaSaslPasswordKey)
+	})
+}


### PR DESCRIPTION
Summary

Adds support for spec.dependencies.kafka.secretRef.

When configured, the operator reads the username and password fields from the referenced Kubernetes Secret and injects them into the rendered configuration. This removes the need to provide credentials as plaintext values in spec.config.kafka.saslUsername and spec.config.kafka.saslPassword.

Why

MilvusKafka did not support referencing Kafka credentials through a Kubernetes Secret. As a result, users connecting to external SASL-authenticated Kafka services such as Amazon MSK, Confluent, or Instaclustr had to store credentials in plaintext in both the Milvus custom resource and the ConfigMap generated by the operator.

This change provides a more secure way to manage Kafka credentials.

Commit#2:
Wires the referenced Secret into reconciliation and the rollout path, and stops treating a failed Secret read as a successful update. The controller now watches Secrets and reconciles the Milvus instances that reference one, so rotating credentials in place takes effect without waiting for the periodic resync. Because the credentials live outside the custom resource, their checksum is recorded in a `milvus.io/kafka-sasl-checksum` annotation on the Milvus object and included in the component configuration checksum. A rotation therefore changes the pods' `checksum/config` annotation and rolls the components, which is what makes them read the refreshed ConfigMap. The `secretRef` name is part of the checksum as well, so pointing the resource at a different Secret also triggers a rollout. Both values are only included when the feature is in use, so instances that do not set `secretRef` keep their current checksum and are not restarted when the operator is upgraded.
Reading the Secret now returns an error instead of empty credentials. NotFound, Forbidden and transient API errors previously overwrote `saslUsername` and `saslPassword` with empty strings and reported success, persisting a configuration that cannot authenticate. A Secret missing either the `username` or the `password` key is rejected the same way, with the missing key named in the error. Reconciliation requeues until the credentials are readable.

Commit#3:
Update Kafka dependency probe to resolve credentials from spec.dependencies.kafka.secretRef.