### PR TITLE
fix: make kafka dependency check independent of topic auto creation

### DIFF
--- a/pkg/external/kafka.go
+++ b/pkg/external/kafka.go
@@ -3,7 +3,6 @@ package external
 import (
 	"context"
 	"crypto/tls"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/segmentio/kafka-go"
@@ -89,7 +88,6 @@ func GetKafkaDialer(conf CheckKafkaConfig) (*kafka.Dialer, error) {
 }
 
 func CheckKafka(conf CheckKafkaConfig) error {
-	// make a new reader that consumes from _milvus-operator, partition 0, at offset 0
 	if len(conf.BrokerList) == 0 {
 		return errors.New("broker list is empty")
 	}
@@ -99,17 +97,46 @@ func CheckKafka(conf CheckKafkaConfig) error {
 		return errors.Wrap(err, "get kafka dialer failed")
 	}
 
-	r := kafka.NewReader(kafka.ReaderConfig{
-		Dialer:  dialer,
-		Brokers: conf.BrokerList,
-		Topic:   "_milvus-operator",
-	})
-	defer r.Close()
+	// Probe the brokers with an ApiVersions request: the dial performs the TLS and
+	// SASL handshake, and ApiVersions is a full protocol round trip, so a success
+	// means the broker is reachable, authenticated and answering requests.
+	//
+	// This probe is deliberately topic independent. It used to read the offset of a
+	// topic named "_milvus-operator", which requires that topic to exist and so
+	// silently depended on the broker having auto.create.topics.enable=true. On a
+	// broker where topic auto creation is disabled the probe could never succeed,
+	// leaving MsgStreamReady false forever, which in turn blocks ReconcileMilvus
+	// from creating any component. The failure was also hard to diagnose: the
+	// missing topic burned the whole DependencyCheckTimeout budget in retries, so
+	// the surfaced error was a dial/DNS timeout on whichever broker happened to be
+	// tried last rather than anything about the topic.
 	var checkKafka = func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), DependencyCheckTimeout)
 		defer cancel()
-		err := r.SetOffsetAt(ctx, time.Now())
-		return errors.Wrap(err, "check consume offset from broker failed")
+		var lastErr error
+		for _, broker := range conf.BrokerList {
+			conn, err := dialer.DialContext(ctx, "tcp", broker)
+			if err != nil {
+				lastErr = errors.Wrapf(err, "dial broker[%s] failed", broker)
+				continue
+			}
+			// DialContext does not bind the connection to the context deadline, so
+			// set it explicitly to keep the probe within DependencyCheckTimeout.
+			if deadline, ok := ctx.Deadline(); ok {
+				if err := conn.SetDeadline(deadline); err != nil {
+					conn.Close()
+					lastErr = errors.Wrapf(err, "set deadline for broker[%s] failed", broker)
+					continue
+				}
+			}
+			_, err = conn.ApiVersions()
+			conn.Close()
+			if err == nil {
+				return nil
+			}
+			lastErr = errors.Wrapf(err, "probe broker[%s] failed", broker)
+		}
+		return errors.Wrap(lastErr, "check kafka brokers failed")
 	}
 	return util.DoWithBackoff("checkKafka", checkKafka, util.DefaultMaxRetry, util.DefaultBackOffInterval)
 }

--- a/pkg/external/kafka_test.go
+++ b/pkg/external/kafka_test.go
@@ -22,6 +22,14 @@ func TestCheckKafkaFailed(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("probe all brokers failed", func(t *testing.T) {
+		conf.BrokerList = []string{"dummy1:9092", "dummy2:9092"}
+		err = CheckKafka(conf)
+		assert.Error(t, err)
+		// every broker is tried, so the last one shows up in the error
+		assert.Contains(t, err.Error(), "dummy2:9092")
+	})
+
 	t.Run("get dialer failed", func(t *testing.T) {
 		conf.SecurityProtocol = "bad"
 		err = CheckKafka(conf)


### PR DESCRIPTION
## Problem

`CheckKafka` verifies the Kafka dependency by reading the consume offset of a hardcoded topic `_milvus-operator`. Nothing ever creates this topic, so the check implicitly relies on the broker having `auto.create.topics.enable=true`.

On clusters where topic auto-creation is disabled (common for shared / production Kafka), the probe can never succeed:

- `MsgStreamReady` stays `False` forever, `ReconcileMilvus` returns early, and the `Milvus` CR sits in `Pending` with no components created at all.
- The failure is also hard to diagnose. The missing topic makes the client retry the leader lookup until the `DependencyCheckTimeout` budget is exhausted, so the error that surfaces is a dial timeout on whichever broker happened to be tried last:

```
dowithbackoff[checkKafka] failed after 3 retries: check consume offset from
broker failed: error dialing all brokers, one of the errors: failed to dial:
failed to open connection to broker4:9092: dial tcp: lookup broker4: i/o timeout
```

This points at DNS/connectivity for a single broker, while in fact every broker is reachable and the missing topic is the real problem. Observed on an on-prem deployment against a shared Kafka cluster with topic auto-creation disabled.

## Fix

Probe the broker with an `ApiVersions` request instead. Dialing already performs the TLS and SASL handshake, and `ApiVersions` is a full protocol round trip — success still means the broker is reachable, authenticated, and answering requests, without depending on any topic existing.

`ReadPartitions()` was considered as an alternative, but with no topic argument it fetches metadata for every topic in the cluster on each reconcile.

Also sets the connection deadline from the caller's context, since `DialContext` does not bind the returned connection to it.

## Testing

- Unit tests updated (`pkg/external/kafka_test.go`).
- With auto-created or pre-created topics (the previously working paths), the check behaves as before: it succeeds against a reachable, authenticated broker.