### PR TITLE
fix: make kafka secretRef work with private CAs and authz-enabled clusters

### DIFF
--- a/pkg/controllers/configmaps.go
+++ b/pkg/controllers/configmaps.go
@@ -35,26 +35,36 @@ func (r *MilvusReconciler) getMinioAccessInfo(ctx context.Context, mc v1beta1.Mi
 
 }
 
-// getKafkaSaslInfo reads the kafka SASL credentials from the referenced secret.
-// Both the username & the password key are required.
-func getKafkaSaslInfo(ctx context.Context, cli client.Client, mc v1beta1.Milvus) (string, string, error) {
+// kafkaSecret is the content of the secret named by spec.dependencies.kafka.secretRef.
+type kafkaSecret struct {
+	Username string
+	Password string
+	// CACert is set only for brokers signed by a private CA, which the
+	// container's system roots cannot verify.
+	CACert []byte
+}
+
+// getKafkaSecret reads the kafka credentials from the referenced secret. Both the
+// username & the password key are required, the CA cert is optional.
+func getKafkaSecret(ctx context.Context, cli client.Client, mc v1beta1.Milvus) (kafkaSecret, error) {
+	var ret kafkaSecret
 	if mc.Spec.Dep.Kafka.SecretRef == "" {
-		return "", "", nil
+		return ret, nil
 	}
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: mc.Namespace, Name: mc.Spec.Dep.Kafka.SecretRef}
 	if err := cli.Get(ctx, key, secret); err != nil {
-		return "", "", errors.Wrapf(err, "get kafka sasl secret[%s]", key)
+		return ret, errors.Wrapf(err, "get kafka sasl secret[%s]", key)
 	}
-	username, password := secret.Data[KafkaSaslUsernameKey], secret.Data[KafkaSaslPasswordKey]
-	if len(username) == 0 {
-		return "", "", errors.Errorf("kafka sasl secret[%s] has no [%s] key", key, KafkaSaslUsernameKey)
+	for _, required := range []string{KafkaSaslUsernameKey, KafkaSaslPasswordKey} {
+		if len(secret.Data[required]) == 0 {
+			return ret, errors.Errorf("kafka sasl secret[%s] has no [%s] key", key, required)
+		}
 	}
-	if len(password) == 0 {
-		return "", "", errors.Errorf("kafka sasl secret[%s] has no [%s] key", key, KafkaSaslPasswordKey)
-	}
-
-	return string(username), string(password), nil
+	ret.Username = string(secret.Data[KafkaSaslUsernameKey])
+	ret.Password = string(secret.Data[KafkaSaslPasswordKey])
+	ret.CACert = secret.Data[KafkaCACertKey]
+	return ret, nil
 }
 
 // SyncKafkaSaslCheckSum records the checksum of the kafka SASL credentials in an annotation
@@ -64,11 +74,12 @@ func (r *MilvusReconciler) SyncKafkaSaslCheckSum(ctx context.Context, mc *v1beta
 	newCheckSum := ""
 	if mc.Spec.Dep.MsgStreamType == v1beta1.MsgStreamTypeKafka &&
 		mc.Spec.Dep.Kafka.SecretRef != "" {
-		username, password, err := getKafkaSaslInfo(ctx, r.Client, *mc)
+		kafkaSecret, err := getKafkaSecret(ctx, r.Client, *mc)
 		if err != nil {
 			return err
 		}
-		newCheckSum = util.CheckSum([]byte(username + ":" + password))
+		// the CA is mounted into the pods too, and is read only at startup
+		newCheckSum = util.CheckSum([]byte(kafkaSecret.Username + ":" + kafkaSecret.Password + ":" + string(kafkaSecret.CACert)))
 	}
 	if oldCheckSum == newCheckSum {
 		return nil
@@ -82,7 +93,7 @@ func (r *MilvusReconciler) SyncKafkaSaslCheckSum(ctx context.Context, mc *v1beta
 		}
 		mc.Annotations[v1beta1.KafkaSaslCheckSumAnnotation] = newCheckSum
 	}
-	r.logger.Info("kafka sasl credentials changed, update checksum annotation",
+	r.logger.Info("kafka credentials changed, update checksum annotation",
 		"namespace", mc.Namespace, "name", mc.Name)
 	return errors.Wrap(r.Update(ctx, mc), "update kafka sasl checksum annotation")
 }
@@ -113,14 +124,9 @@ func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvu
 	switch mc.Spec.Dep.MsgStreamType {
 	case v1beta1.MsgStreamTypeKafka:
 		util.SetStringSlice(conf, mc.Spec.Dep.Kafka.BrokerList, "kafka", "brokerList")
-		if mc.Spec.Dep.Kafka.SecretRef != "" {
-			username, password, err := getKafkaSaslInfo(ctx, r.Client, mc)
-			if err != nil {
-				return err
-			}
-			util.SetValue(conf, username, "kafka", "saslUsername")
-			util.SetValue(conf, password, "kafka", "saslPassword")
-		}
+		// Credentials from secretRef are injected into the pods as env vars, not
+		// written here: a configmap has no encryption at rest, no RBAC separation
+		// from ordinary config, and is excluded from secret scanning.
 		// delete other mq config to make milvus use kafka
 		delete(conf, "pulsar")
 		delete(conf, "rocksmq")

--- a/pkg/controllers/configmaps.go
+++ b/pkg/controllers/configmaps.go
@@ -127,6 +127,17 @@ func (r *MilvusReconciler) updateConfigMap(ctx context.Context, mc v1beta1.Milvu
 		// Credentials from secretRef are injected into the pods as env vars, not
 		// written here: a configmap has no encryption at rest, no RBAC separation
 		// from ordinary config, and is excluded from secret scanning.
+		if mc.Spec.Dep.Kafka.SecretRef != "" {
+			kafkaSecret, err := getKafkaSecret(ctx, r.Client, mc)
+			if err != nil {
+				return err
+			}
+			// A path, not the cert: the operator mounts it from the same secret.
+			if len(kafkaSecret.CACert) > 0 {
+				util.SetValue(conf, true, "kafka", "ssl", "enabled")
+				util.SetValue(conf, KafkaCACertPath, "kafka", "ssl", "tlsCaCert")
+			}
+		}
 		// delete other mq config to make milvus use kafka
 		delete(conf, "pulsar")
 		delete(conf, "rocksmq")

--- a/pkg/controllers/configmaps_test.go
+++ b/pkg/controllers/configmaps_test.go
@@ -344,11 +344,21 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		cm := &corev1.ConfigMap{}
 		cm.Namespace = "ns"
 		cm.Name = "cm1"
-		// only the minio secret is read; the kafka credentials reach the pods as env
+		// the minio secret (NotFound) and the kafka secret, read for the CA only
 		mockClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")).
-			Times(1)
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
+					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
+				}
+				obj.(*corev1.Secret).Data = map[string][]byte{
+					KafkaSaslUsernameKey: []byte("kafka-user"),
+					KafkaSaslPasswordKey: []byte("kafka-pass"),
+					KafkaCACertKey:       []byte("ca-cert-bytes"),
+				}
+				return nil
+			}).
+			Times(2)
 
 		err := r.updateConfigMap(ctx, mc, cm)
 		assert.NoError(t, err)
@@ -359,6 +369,41 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		assert.Equal(t, []interface{}{"broker:9092"}, kafka["brokerList"])
 		assert.NotContains(t, kafka, "saslUsername")
 		assert.NotContains(t, kafka, "saslPassword")
+		// only a path to the mounted cert, never the cert itself
+		ssl := kafka["ssl"].(map[string]interface{})
+		assert.Equal(t, true, ssl["enabled"])
+		assert.Equal(t, KafkaCACertPath, ssl["tlsCaCert"])
+		assert.NotContains(t, cm.Data[UserYaml], "ca-cert-bytes")
+	})
+
+	t.Run("kafka secret without a CA leaves ssl alone", func(t *testing.T) {
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+		mc.Spec.Conf.Data = nil
+		cm := &corev1.ConfigMap{}
+		cm.Namespace = "ns"
+		cm.Name = "cm1"
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
+				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
+					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
+				}
+				obj.(*corev1.Secret).Data = map[string][]byte{
+					KafkaSaslUsernameKey: []byte("kafka-user"),
+					KafkaSaslPasswordKey: []byte("kafka-pass"),
+				}
+				return nil
+			}).
+			Times(2)
+
+		err := r.updateConfigMap(ctx, mc, cm)
+		assert.NoError(t, err)
+
+		conf := map[string]interface{}{}
+		assert.NoError(t, yaml.Unmarshal([]byte(cm.Data[UserYaml]), &conf))
+		assert.NotContains(t, conf["kafka"].(map[string]interface{}), "ssl")
 	})
 }
 

--- a/pkg/controllers/configmaps_test.go
+++ b/pkg/controllers/configmaps_test.go
@@ -336,7 +336,7 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		}
 	})
 
-	t.Run("kafka sasl secretRef populates saslUsername/saslPassword from secret", func(t *testing.T) {
+	t.Run("kafka sasl secretRef keeps credentials out of the config", func(t *testing.T) {
 		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
 		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
 		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
@@ -344,21 +344,11 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		cm := &corev1.ConfigMap{}
 		cm.Namespace = "ns"
 		cm.Name = "cm1"
-		// get the minio secret (NotFound) & the kafka sasl secret
+		// only the minio secret is read; the kafka credentials reach the pods as env
 		mockClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
-				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
-					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
-				}
-				secret := obj.(*corev1.Secret)
-				secret.Data = map[string][]byte{
-					KafkaSaslUsernameKey: []byte("kafka-user"),
-					KafkaSaslPasswordKey: []byte("kafka-pass"),
-				}
-				return nil
-			}).
-			Times(2)
+			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")).
+			Times(1)
 
 		err := r.updateConfigMap(ctx, mc, cm)
 		assert.NoError(t, err)
@@ -366,52 +356,88 @@ func TestReconcileOneConfigMap_Existed(t *testing.T) {
 		conf := map[string]interface{}{}
 		assert.NoError(t, yaml.Unmarshal([]byte(cm.Data[UserYaml]), &conf))
 		kafka := conf["kafka"].(map[string]interface{})
-		assert.Equal(t, "kafka-user", kafka["saslUsername"])
-		assert.Equal(t, "kafka-pass", kafka["saslPassword"])
+		assert.Equal(t, []interface{}{"broker:9092"}, kafka["brokerList"])
+		assert.NotContains(t, kafka, "saslUsername")
+		assert.NotContains(t, kafka, "saslPassword")
 	})
+}
 
-	t.Run("kafka sasl secret read failed", func(t *testing.T) {
-		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
-		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
-		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
-		mc.Spec.Conf.Data = nil
-		cm := &corev1.ConfigMap{}
-		cm.Namespace = "ns"
-		cm.Name = "cm1"
-		// the minio secret & the kafka sasl secret are both missing
-		mockClient.EXPECT().
-			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")).
-			Times(2)
+func TestGetKafkaSecret(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.checkMocks()
+	ctx, cli := env.ctx, env.Reconciler.Client
 
-		err := r.updateConfigMap(ctx, mc, cm)
-		assert.Error(t, err)
-	})
-
-	t.Run("kafka sasl secret missing required key", func(t *testing.T) {
-		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
-		mc.Spec.Dep.Kafka.BrokerList = []string{"broker:9092"}
-		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
-		mc.Spec.Conf.Data = nil
-		cm := &corev1.ConfigMap{}
-		cm.Namespace = "ns"
-		cm.Name = "cm1"
-		mockClient.EXPECT().
+	withSecretRef := func() v1beta1.Milvus {
+		mc := env.Inst.DeepCopy()
+		mc.Namespace = "ns"
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-secret"
+		return *mc
+	}
+	returnSecret := func(data map[string][]byte) {
+		env.MockClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
 			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
-				if key.Name != mc.Spec.Dep.Kafka.SecretRef {
-					return k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")
-				}
-				secret := obj.(*corev1.Secret)
-				secret.Data = map[string][]byte{
-					KafkaSaslUsernameKey: []byte("kafka-user"),
-				}
+				obj.(*corev1.Secret).Data = data
 				return nil
-			}).
-			Times(2)
+			})
+	}
 
-		err := r.updateConfigMap(ctx, mc, cm)
+	t.Run("no secretRef reads nothing", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Dep.Kafka.SecretRef = ""
+		ret, err := getKafkaSecret(ctx, cli, *mc)
+		assert.NoError(t, err)
+		assert.Equal(t, kafkaSecret{}, ret)
+	})
+
+	t.Run("all keys present", func(t *testing.T) {
+		returnSecret(map[string][]byte{
+			KafkaSaslUsernameKey: []byte("user"),
+			KafkaSaslPasswordKey: []byte("pass"),
+			KafkaCACertKey:       []byte("pem"),
+		})
+		ret, err := getKafkaSecret(ctx, cli, withSecretRef())
+		assert.NoError(t, err)
+		assert.Equal(t, kafkaSecret{Username: "user", Password: "pass", CACert: []byte("pem")}, ret)
+	})
+
+	t.Run("CA is optional", func(t *testing.T) {
+		returnSecret(map[string][]byte{
+			KafkaSaslUsernameKey: []byte("user"),
+			KafkaSaslPasswordKey: []byte("pass"),
+		})
+		ret, err := getKafkaSecret(ctx, cli, withSecretRef())
+		assert.NoError(t, err)
+		assert.Nil(t, ret.CACert)
+	})
+
+	t.Run("username is required", func(t *testing.T) {
+		returnSecret(map[string][]byte{KafkaSaslPasswordKey: []byte("pass")})
+		_, err := getKafkaSecret(ctx, cli, withSecretRef())
+		assert.ErrorContains(t, err, KafkaSaslUsernameKey)
+	})
+
+	t.Run("password is required", func(t *testing.T) {
+		returnSecret(map[string][]byte{KafkaSaslUsernameKey: []byte("user")})
+		_, err := getKafkaSecret(ctx, cli, withSecretRef())
 		assert.ErrorContains(t, err, KafkaSaslPasswordKey)
+	})
+
+	t.Run("empty value counts as missing", func(t *testing.T) {
+		returnSecret(map[string][]byte{
+			KafkaSaslUsernameKey: []byte("user"),
+			KafkaSaslPasswordKey: {},
+		})
+		_, err := getKafkaSecret(ctx, cli, withSecretRef())
+		assert.ErrorContains(t, err, KafkaSaslPasswordKey)
+	})
+
+	t.Run("read failure names the secret", func(t *testing.T) {
+		env.MockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr"))
+		_, err := getKafkaSecret(ctx, cli, withSecretRef())
+		assert.ErrorContains(t, err, "kafka-secret")
 	})
 }
 
@@ -422,7 +448,7 @@ func TestMilvusReconciler_SyncKafkaSaslCheckSum(t *testing.T) {
 	r := env.Reconciler
 	ctx := env.ctx
 
-	expectGetKafkaSecret := func(username, password string) {
+	expectGetKafkaSecret := func(username, password string, ca ...string) {
 		mockClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
 			DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...any) error {
@@ -430,6 +456,9 @@ func TestMilvusReconciler_SyncKafkaSaslCheckSum(t *testing.T) {
 				secret.Data = map[string][]byte{
 					KafkaSaslUsernameKey: []byte(username),
 					KafkaSaslPasswordKey: []byte(password),
+				}
+				if len(ca) > 0 {
+					secret.Data[KafkaCACertKey] = []byte(ca[0])
 				}
 				return nil
 			})
@@ -466,6 +495,22 @@ func TestMilvusReconciler_SyncKafkaSaslCheckSum(t *testing.T) {
 		assert.NotEmpty(t, rotatedCheckSum)
 		assert.NotEqual(t, checkSum, rotatedCheckSum)
 		assert.NotEqual(t, GetConfCheckSum(mc.Spec), GetConfCheckSumWithRefs(mc))
+	})
+
+	t.Run("rotating only the CA still rolls the pods", func(t *testing.T) {
+		mc := env.Inst.DeepCopy()
+		mc.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		mc.Spec.Dep.Kafka.SecretRef = "kafka-sasl-secret"
+
+		expectGetKafkaSecret("kafka-user", "kafka-pass", "old-ca")
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		withOldCA := mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation]
+
+		expectGetKafkaSecret("kafka-user", "kafka-pass", "new-ca")
+		mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		assert.NoError(t, r.SyncKafkaSaslCheckSum(ctx, mc))
+		assert.NotEqual(t, withOldCA, mc.GetAnnotations()[v1beta1.KafkaSaslCheckSumAnnotation])
 	})
 
 	t.Run("annotation removed when secretRef unset", func(t *testing.T) {

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -335,6 +335,9 @@ func updateBuiltInVolumes(template *corev1.PodTemplateSpec, updater deploymentUp
 		configVolumeByName(updater.GetMilvus().GetActiveConfigMap()),
 		toolVolume,
 	}
+	if secretRef := updater.GetKafkaSecretRef(); secretRef != "" {
+		builtInVolumes = append(builtInVolumes, kafkaCAVolumeBySecret(secretRef))
+	}
 	for _, volume := range builtInVolumes {
 		addVolume(&template.Spec.Volumes, volume)
 	}
@@ -424,6 +427,9 @@ func updateBuiltInVolumeMounts(template *corev1.PodTemplateSpec, updater deploym
 	builtInVolumeMounts := []corev1.VolumeMount{
 		configVolumeMount,
 		toolVolumeMount,
+	}
+	if updater.GetKafkaSecretRef() != "" {
+		builtInVolumeMounts = append(builtInVolumeMounts, kafkaCAVolumeMount)
 	}
 	removeVolumeMounts(&container.VolumeMounts, MilvusConfigVolumeName)
 	for _, volumeMount := range builtInVolumeMounts {

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -30,6 +30,7 @@ type deploymentUpdater interface {
 	GetMergedComponentSpec() ComponentSpec
 	GetArgs() []string
 	GetSecretRef() string
+	GetKafkaSecretRef() string
 	GetStorageEndpointEnv() []corev1.EnvVar
 	GetMilvus() *v1beta1.Milvus
 	RollingUpdateImageDependencyReady() bool
@@ -354,6 +355,7 @@ func updateMilvusContainer(template *corev1.PodTemplateSpec, updater deploymentU
 	container.Args = updater.GetArgs()
 	env := MergeEnvVar(updater.GetStorageEndpointEnv(), mergedComSpec.Env)
 	env = append(env, GetStorageSecretRefEnv(updater.GetSecretRef())...)
+	env = append(env, GetKafkaSecretRefEnv(updater.GetKafkaSecretRef())...)
 	container.Env = MergeEnvVar(container.Env, env)
 	metricPort := corev1.ContainerPort{
 		Name:          MetricPortName,
@@ -658,6 +660,13 @@ func (m milvusDeploymentUpdater) GetArgs() []string {
 }
 func (m milvusDeploymentUpdater) GetSecretRef() string {
 	return m.Spec.Dep.Storage.SecretRef
+}
+
+func (m milvusDeploymentUpdater) GetKafkaSecretRef() string {
+	if m.Spec.Dep.MsgStreamType != v1beta1.MsgStreamTypeKafka {
+		return ""
+	}
+	return m.Spec.Dep.Kafka.SecretRef
 }
 
 func (m milvusDeploymentUpdater) GetMilvus() *v1beta1.Milvus {

--- a/pkg/controllers/deployment_updater_test.go
+++ b/pkg/controllers/deployment_updater_test.go
@@ -23,6 +23,56 @@ func TestMilvusDeploymentUpdater_KafkaSecretRefEnv(t *testing.T) {
 		assert.Empty(t, updater.GetKafkaSecretRef())
 	})
 
+	t.Run("CA volume follows secretRef", func(t *testing.T) {
+		inst := env.Inst.DeepCopy()
+		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		inst.Spec.Dep.Kafka.SecretRef = "kafka-secret"
+		updater := newMilvusDeploymentUpdater(*inst, env.Reconciler.Scheme, MilvusStandalone)
+
+		template := new(corev1.PodTemplateSpec)
+		template.Annotations = map[string]string{}
+		updateMilvusContainer(template, updater, true)
+		updateBuiltInVolumes(template, updater)
+		updateBuiltInVolumeMounts(template, updater)
+
+		var volume *corev1.Volume
+		for i := range template.Spec.Volumes {
+			if template.Spec.Volumes[i].Name == KafkaCAVolumeName {
+				volume = &template.Spec.Volumes[i]
+			}
+		}
+		assert.NotNil(t, volume)
+		assert.Equal(t, "kafka-secret", volume.Secret.SecretName)
+		// only the CA is projected, so the credentials are not exposed as files
+		assert.Equal(t, []corev1.KeyToPath{{Key: KafkaCACertKey, Path: KafkaCACertKey}}, volume.Secret.Items)
+		assert.True(t, *volume.Secret.Optional)
+
+		idx := GetContainerIndex(template.Spec.Containers, MilvusStandalone.Name)
+		var mounted bool
+		for _, m := range template.Spec.Containers[idx].VolumeMounts {
+			if m.Name == KafkaCAVolumeName {
+				mounted = true
+				assert.Equal(t, KafkaCAMountPath, m.MountPath)
+				assert.True(t, m.ReadOnly)
+			}
+		}
+		assert.True(t, mounted)
+	})
+
+	t.Run("no CA volume without secretRef", func(t *testing.T) {
+		inst := env.Inst.DeepCopy()
+		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		inst.Spec.Dep.Kafka.SecretRef = ""
+		updater := newMilvusDeploymentUpdater(*inst, env.Reconciler.Scheme, MilvusStandalone)
+
+		template := new(corev1.PodTemplateSpec)
+		template.Annotations = map[string]string{}
+		updateBuiltInVolumes(template, updater)
+		for _, v := range template.Spec.Volumes {
+			assert.NotEqual(t, KafkaCAVolumeName, v.Name)
+		}
+	})
+
 	t.Run("credentials reach the container", func(t *testing.T) {
 		inst := env.Inst.DeepCopy()
 		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka

--- a/pkg/controllers/deployment_updater_test.go
+++ b/pkg/controllers/deployment_updater_test.go
@@ -11,6 +11,46 @@ import (
 	"github.com/zilliztech/milvus-operator/pkg/util"
 )
 
+func TestMilvusDeploymentUpdater_KafkaSecretRefEnv(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.checkMocks()
+
+	t.Run("no env for a non-kafka msgstream", func(t *testing.T) {
+		inst := env.Inst.DeepCopy()
+		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypePulsar
+		inst.Spec.Dep.Kafka.SecretRef = "stale-secret"
+		updater := newMilvusDeploymentUpdater(*inst, env.Reconciler.Scheme, MilvusStandalone)
+		assert.Empty(t, updater.GetKafkaSecretRef())
+	})
+
+	t.Run("credentials reach the container", func(t *testing.T) {
+		inst := env.Inst.DeepCopy()
+		inst.Spec.Dep.MsgStreamType = v1beta1.MsgStreamTypeKafka
+		inst.Spec.Dep.Kafka.SecretRef = "kafka-secret"
+		updater := newMilvusDeploymentUpdater(*inst, env.Reconciler.Scheme, MilvusStandalone)
+		assert.Equal(t, "kafka-secret", updater.GetKafkaSecretRef())
+
+		template := new(corev1.PodTemplateSpec)
+		updateMilvusContainer(template, updater, true)
+		idx := GetContainerIndex(template.Spec.Containers, MilvusStandalone.Name)
+		assert.GreaterOrEqual(t, idx, 0)
+
+		byName := map[string]corev1.EnvVar{}
+		for _, e := range template.Spec.Containers[idx].Env {
+			byName[e.Name] = e
+		}
+		for name, key := range map[string]string{
+			"KAFKA_SASLUSERNAME": KafkaSaslUsernameKey,
+			"KAFKA_SASLPASSWORD": KafkaSaslPasswordKey,
+		} {
+			env, found := byName[name]
+			assert.True(t, found, name)
+			assert.Equal(t, "kafka-secret", env.ValueFrom.SecretKeyRef.Name)
+			assert.Equal(t, key, env.ValueFrom.SecretKeyRef.Key)
+		}
+	})
+}
+
 func TestMilvus_UpdateDeployment(t *testing.T) {
 	env := newTestEnv(t)
 	defer env.checkMocks()

--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -37,6 +37,10 @@ const (
 	AnnotationCheckSum         = "checksum/config"
 	AnnotationMilvusGeneration = v1beta1.AnnotationMilvusGeneration
 
+	KafkaCAVolumeName = "kafka-ca"
+	KafkaCAMountPath  = MilvusConfigRootPath + "/kafka-ca"
+	KafkaCACertPath   = KafkaCAMountPath + "/" + KafkaCACertKey
+
 	ToolsVolumeName = "tools"
 	ToolsMountPath  = "/milvus/tools"
 	RunScriptPath   = ToolsMountPath + "/run.sh"
@@ -625,7 +629,32 @@ var (
 		ReadOnly:  true,
 		MountPath: MilvusConfigmapMountPath,
 	}
+
+	kafkaCAVolumeMount = corev1.VolumeMount{
+		Name:      KafkaCAVolumeName,
+		ReadOnly:  true,
+		MountPath: KafkaCAMountPath,
+	}
 )
+
+// kafkaCAVolumeBySecret mounts only the CA cert out of the kafka secret, so the
+// credentials in it are not exposed as files. It is optional: a secret without a
+// CA cert is the normal case for publicly trusted brokers.
+func kafkaCAVolumeBySecret(name string) corev1.Volume {
+	readOnlyMode := int32(0444)
+	optional := true
+	return corev1.Volume{
+		Name: KafkaCAVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  name,
+				Items:       []corev1.KeyToPath{{Key: KafkaCACertKey, Path: KafkaCACertKey}},
+				DefaultMode: &readOnlyMode,
+				Optional:    &optional,
+			},
+		},
+	}
+}
 
 func configVolumeByName(name string) corev1.Volume {
 	// so that non root user can change the config

--- a/pkg/controllers/deployments.go
+++ b/pkg/controllers/deployments.go
@@ -33,6 +33,7 @@ const (
 	SecretKey                  = "secretkey"
 	KafkaSaslUsernameKey       = "username"
 	KafkaSaslPasswordKey       = "password"
+	KafkaCACertKey             = "ca.pem"
 	AnnotationCheckSum         = "checksum/config"
 	AnnotationMilvusGeneration = v1beta1.AnnotationMilvusGeneration
 
@@ -83,6 +84,32 @@ func (r *MilvusReconciler) getMinioPortEnvIfServiceExists(ctx context.Context, m
 	}
 
 	return GetStorageEndpointEnv(mc.Spec.Dep.Storage.Endpoint, GetMinioSecure(mc.Spec.Conf.Data)), nil
+}
+
+// GetKafkaSecretRefEnv passes the SASL credentials to milvus as env vars, which
+// override kafka.saslUsername & kafka.saslPassword from the config file.
+func GetKafkaSecretRefEnv(secretRef string) []corev1.EnvVar {
+	env := []corev1.EnvVar{}
+	if secretRef == "" {
+		return env
+	}
+	for _, ref := range []struct{ name, key string }{
+		{"KAFKA_SASLPASSWORD", KafkaSaslPasswordKey},
+		{"KAFKA_SASLUSERNAME", KafkaSaslUsernameKey},
+	} {
+		env = append(env, corev1.EnvVar{
+			Name: ref.name,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretRef,
+					},
+					Key: ref.key,
+				},
+			},
+		})
+	}
+	return env
 }
 
 func GetStorageSecretRefEnv(secretRef string) []corev1.EnvVar {

--- a/pkg/controllers/deployments_test.go
+++ b/pkg/controllers/deployments_test.go
@@ -332,6 +332,24 @@ func TestGetStorageSecretRefEnv(t *testing.T) {
 	assert.Len(t, ret, 4)
 }
 
+func TestGetKafkaSecretRefEnv(t *testing.T) {
+	assert.Len(t, GetKafkaSecretRefEnv(""), 0)
+
+	ret := GetKafkaSecretRefEnv("kafka-secret")
+	assert.Len(t, ret, 2)
+	// the order is fixed: a varying pod template would roll the pods forever
+	assert.Equal(t, "KAFKA_SASLPASSWORD", ret[0].Name)
+	assert.Equal(t, "KAFKA_SASLUSERNAME", ret[1].Name)
+	for _, env := range ret {
+		// referenced, never inlined: a value here would land in the deployment spec
+		assert.NotNil(t, env.ValueFrom.SecretKeyRef)
+		assert.Equal(t, "kafka-secret", env.ValueFrom.SecretKeyRef.Name)
+		assert.Empty(t, env.Value)
+	}
+	assert.Equal(t, KafkaSaslPasswordKey, ret[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, KafkaSaslUsernameKey, ret[1].ValueFrom.SecretKeyRef.Key)
+}
+
 func TestGetStorageEndpointEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -420,9 +420,9 @@ func (r *MilvusStatusSyncer) GetMsgStreamCondition(
 				Message: err.Error(),
 			}, nil
 		}
-		// credentials from the referenced secret take precedence over the plaintext config
+		// the referenced secret takes precedence over the plaintext config
 		if mc.Spec.Dep.Kafka.SecretRef != "" {
-			username, password, err := getKafkaSaslInfo(ctx, r.Client, mc)
+			kafkaSecret, err := getKafkaSecret(ctx, r.Client, mc)
 			if err != nil {
 				return v1beta1.MilvusCondition{
 					Type:    v1beta1.MsgStreamReady,
@@ -430,8 +430,9 @@ func (r *MilvusStatusSyncer) GetMsgStreamCondition(
 					Message: err.Error(),
 				}, nil
 			}
-			kafkaConf.SASLUsername = username
-			kafkaConf.SASLPassword = password
+			kafkaConf.SASLUsername = kafkaSecret.Username
+			kafkaConf.SASLPassword = kafkaSecret.Password
+			kafkaConf.CACert = kafkaSecret.CACert
 		}
 		kafkaConf.BrokerList = mc.Spec.Dep.Kafka.BrokerList
 		getter = wrapKafkaConditonGetter(ctx, r.logger, mc.Spec.Dep.Kafka, *kafkaConf)

--- a/pkg/controllers/status_cluster_test.go
+++ b/pkg/controllers/status_cluster_test.go
@@ -718,10 +718,12 @@ func TestMilvusStatusSyncer_GetMsgStreamCondition_KafkaSecretRef(t *testing.T) {
 			return nil
 		})
 		defer stubs.Reset()
-		expectGetSecret(map[string][]byte{
+		saslSecret := map[string][]byte{
 			KafkaSaslUsernameKey: []byte("kafka-user"),
 			KafkaSaslPasswordKey: []byte("kafka-pass"),
-		})
+			KafkaCACertKey:       []byte("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"),
+		}
+		expectGetSecret(saslSecret)
 
 		ret, err := s.GetMsgStreamCondition(ctx, milvus)
 		assert.NoError(t, err)
@@ -730,6 +732,7 @@ func TestMilvusStatusSyncer_GetMsgStreamCondition_KafkaSecretRef(t *testing.T) {
 		assert.Equal(t, "kafka-pass", probed.SASLPassword)
 		assert.Equal(t, "SASL_SSL", probed.SecurityProtocol)
 		assert.Equal(t, milvus.Spec.Dep.Kafka.BrokerList, probed.BrokerList)
+		assert.Contains(t, string(probed.CACert), "BEGIN CERTIFICATE")
 	})
 
 	t.Run("secret not found", func(t *testing.T) {

--- a/pkg/external/kafka.go
+++ b/pkg/external/kafka.go
@@ -3,7 +3,8 @@ package external
 import (
 	"context"
 	"crypto/tls"
-	"time"
+	"crypto/x509"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	"github.com/segmentio/kafka-go"
@@ -21,6 +22,7 @@ type CheckKafkaConfig struct {
 	SASLMechanisms   string   `json:"saslMechanisms"`
 	SASLUsername     string   `json:"saslUsername"`
 	SASLPassword     string   `json:"saslPassword"`
+	CACert           []byte   `json:"-"`
 }
 
 // GetKafkaConfFromCR get check kafka config from CR
@@ -63,6 +65,13 @@ func GetKafkaDialer(conf CheckKafkaConfig) (*kafka.Dialer, error) {
 	var saslMechanism sasl.Mechanism
 	if useTls {
 		tlsConfig = &tls.Config{}
+		if len(conf.CACert) > 0 {
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(conf.CACert) {
+				return nil, errors.New("no certificate found in kafka CA cert")
+			}
+			tlsConfig.RootCAs = pool
+		}
 	}
 	if useSasl {
 		switch conf.SASLMechanisms {
@@ -89,7 +98,9 @@ func GetKafkaDialer(conf CheckKafkaConfig) (*kafka.Dialer, error) {
 }
 
 func CheckKafka(conf CheckKafkaConfig) error {
-	// make a new reader that consumes from _milvus-operator, partition 0, at offset 0
+	// A metadata request proves the brokers are reachable and that TLS & SASL
+	// succeed. It needs no topic to exist and no topic ACL, so it works on
+	// clusters where authorization is enabled and topics are managed elsewhere.
 	if len(conf.BrokerList) == 0 {
 		return errors.New("broker list is empty")
 	}
@@ -99,17 +110,41 @@ func CheckKafka(conf CheckKafkaConfig) error {
 		return errors.Wrap(err, "get kafka dialer failed")
 	}
 
-	r := kafka.NewReader(kafka.ReaderConfig{
-		Dialer:  dialer,
-		Brokers: conf.BrokerList,
-		Topic:   "_milvus-operator",
-	})
-	defer r.Close()
 	var checkKafka = func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), DependencyCheckTimeout)
 		defer cancel()
-		err := r.SetOffsetAt(ctx, time.Now())
-		return errors.Wrap(err, "check consume offset from broker failed")
+		// Any broker answering is enough: the others may be mid-restart.
+		var errs []error
+		for _, broker := range conf.BrokerList {
+			err := checkKafkaBroker(ctx, dialer, broker)
+			if err == nil {
+				return nil
+			}
+			errs = append(errs, err)
+		}
+		return stderrors.Join(errs...)
 	}
 	return util.DoWithBackoff("checkKafka", checkKafka, util.DefaultMaxRetry, util.DefaultBackOffInterval)
+}
+
+// checkKafkaBroker dials one broker and asks it for cluster metadata. Dialing
+// covers TCP, TLS and the SASL handshake; the metadata request proves the
+// connection is usable and needs no topic and no topic ACL.
+// A var so the broker loop can be tested without a live cluster.
+var checkKafkaBroker = func(ctx context.Context, dialer *kafka.Dialer, broker string) error {
+	conn, err := dialer.DialContext(ctx, "tcp", broker)
+	if err != nil {
+		return errors.Wrapf(err, "dial broker[%s]", broker)
+	}
+	defer conn.Close()
+	// A conn has no deadline of its own, so metadata could outlive the timeout.
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return errors.Wrapf(err, "set deadline on broker[%s]", broker)
+		}
+	}
+	if _, err := conn.Brokers(); err != nil {
+		return errors.Wrapf(err, "get metadata from broker[%s]", broker)
+	}
+	return nil
 }

--- a/pkg/external/kafka_test.go
+++ b/pkg/external/kafka_test.go
@@ -1,8 +1,20 @@
 package external
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
+	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/zilliztech/milvus-operator/apis/milvus.io/v1beta1"
@@ -26,6 +38,78 @@ func TestCheckKafkaFailed(t *testing.T) {
 		conf.SecurityProtocol = "bad"
 		err = CheckKafka(conf)
 		assert.Error(t, err)
+	})
+}
+
+func TestCheckKafkaBrokerIteration(t *testing.T) {
+	// a listener that accepts and hangs up: dialing works, metadata does not
+	deadBroker, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer deadBroker.Close()
+	go func() {
+		for {
+			conn, err := deadBroker.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	t.Run("dial ok, metadata fails", func(t *testing.T) {
+		err := CheckKafka(CheckKafkaConfig{BrokerList: []string{deadBroker.Addr().String()}})
+		assert.ErrorContains(t, err, "get metadata from broker")
+	})
+
+	t.Run("every broker is reported, not just the last", func(t *testing.T) {
+		unroutable := "127.0.0.1:1"
+		err := CheckKafka(CheckKafkaConfig{BrokerList: []string{unroutable, deadBroker.Addr().String()}})
+		assert.ErrorContains(t, err, unroutable)
+		assert.ErrorContains(t, err, deadBroker.Addr().String())
+	})
+
+	t.Run("gives up within the timeout", func(t *testing.T) {
+		start := time.Now()
+		err := CheckKafka(CheckKafkaConfig{BrokerList: []string{"10.255.255.1:9092"}})
+		assert.Error(t, err)
+		// DefaultMaxRetry attempts, each bounded by DependencyCheckTimeout
+		assert.Less(t, time.Since(start), DependencyCheckTimeout*5)
+	})
+}
+
+func TestCheckKafkaBrokerLoop(t *testing.T) {
+	original := checkKafkaBroker
+	defer func() { checkKafkaBroker = original }()
+
+	t.Run("first healthy broker wins", func(t *testing.T) {
+		var probed []string
+		checkKafkaBroker = func(ctx context.Context, dialer *kafka.Dialer, broker string) error {
+			probed = append(probed, broker)
+			if broker == "second:9092" {
+				return nil
+			}
+			return errors.New("nope")
+		}
+		err := CheckKafka(CheckKafkaConfig{BrokerList: []string{"first:9092", "second:9092", "third:9092"}})
+		assert.NoError(t, err)
+		// stops at the first success instead of probing the rest
+		assert.Equal(t, []string{"first:9092", "second:9092"}, probed)
+	})
+
+	t.Run("single healthy broker", func(t *testing.T) {
+		checkKafkaBroker = func(ctx context.Context, dialer *kafka.Dialer, broker string) error {
+			return nil
+		}
+		assert.NoError(t, CheckKafka(CheckKafkaConfig{BrokerList: []string{"only:9092"}}))
+	})
+
+	t.Run("all unhealthy reports each one", func(t *testing.T) {
+		checkKafkaBroker = func(ctx context.Context, dialer *kafka.Dialer, broker string) error {
+			return errors.Errorf("broker[%s] down", broker)
+		}
+		err := CheckKafka(CheckKafkaConfig{BrokerList: []string{"a:9092", "b:9092"}})
+		assert.ErrorContains(t, err, "a:9092")
+		assert.ErrorContains(t, err, "b:9092")
 	})
 }
 
@@ -109,6 +193,61 @@ func TestGetKafkaDialer(t *testing.T) {
 		_, err := GetKafkaDialer(conf)
 		assert.Error(t, err)
 	})
+}
+
+func TestGetKafkaDialerCACert(t *testing.T) {
+	t.Run("no CA falls back to system roots", func(t *testing.T) {
+		dialer, err := GetKafkaDialer(CheckKafkaConfig{SecurityProtocol: "SSL"})
+		assert.NoError(t, err)
+		assert.NotNil(t, dialer.TLS)
+		assert.Nil(t, dialer.TLS.RootCAs)
+	})
+
+	t.Run("CA is trusted", func(t *testing.T) {
+		dialer, err := GetKafkaDialer(CheckKafkaConfig{
+			SecurityProtocol: "SSL",
+			CACert:           testCACert(t),
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, dialer.TLS.RootCAs)
+	})
+
+	t.Run("unparsable CA fails loudly", func(t *testing.T) {
+		// silently ignoring it would fall back to system roots and report the
+		// broker as untrusted, which points at the wrong thing
+		_, err := GetKafkaDialer(CheckKafkaConfig{
+			SecurityProtocol: "SSL",
+			CACert:           []byte("not a pem"),
+		})
+		assert.ErrorContains(t, err, "no certificate found")
+	})
+
+	t.Run("CA is ignored without tls", func(t *testing.T) {
+		dialer, err := GetKafkaDialer(CheckKafkaConfig{
+			SecurityProtocol: "PLAINTEXT",
+			CACert:           testCACert(t),
+		})
+		assert.NoError(t, err)
+		assert.Nil(t, dialer.TLS)
+	})
+}
+
+// testCACert returns a self-signed certificate in PEM form.
+func testCACert(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
 func TestGetKafkaConfFromCR(t *testing.T) {


### PR DESCRIPTION
What

Adds full spec.dependencies.kafka.secretRef support for private-CA Kafka clusters with auth enabled.
- Keep Kafka credentials in the Secret and inject them via KAFKA_SASLUSERNAME / KAFKA_SASLPASSWORD env variables
- Add optional CA support to CheckKafkaConfig / tls.Config.RootCAs
- Read credentials and CA from the same Secret
- Replace the _milvus-operator offset probe with a metadata request
- Include the CA in the rotation checksum so CA changes roll pods

Why

Previously, secretRef credentials were rendered into user.yaml, moving secrets into a ConfigMap and losing Secret-level RBAC/encryption benefits.
Kafka TLS also only used system roots, so private-CA brokers failed certificate validation.
The probe depended on a hardcoded _milvus-operator topic, requiring topic creation and ACLs. A metadata request validates TCP, TLS, SASL, and Kafka protocol connectivity without requiring a topic.
