### PR TITLE
fix: detect manual mode deployment template drift

### DIFF
--- a/pkg/controllers/deploy_ctrl.go
+++ b/pkg/controllers/deploy_ctrl.go
@@ -352,13 +352,18 @@ func (c *DeployControllerBizImpl) HandleManualMode(ctx context.Context, mc v1bet
 	}
 	logger := ctrl.LoggerFrom(ctx).WithName("manual-mode").WithValues("component", c.component.Name)
 	ctx = ctrl.LoggerInto(ctx, logger)
+	podTemplate := c.util.RenderPodTemplateWithoutGroupID(ctx, mc, &currentDeploy.Spec.Template, c.component, true)
+	templateChanged := c.util.IsPodTemplateChanged(ctx, currentDeploy, podTemplate)
 	// should not update deploy with replicas if it's in manual mode
 	if getDeployReplicas(currentDeploy) != 0 {
+		if templateChanged {
+			return errors.Wrapf(ErrRequeue,
+				"[%s]'s active deployment pod template is out of sync in manual mode", c.component.Name)
+		}
 		return nil
 	}
-	podTemplate := c.util.RenderPodTemplateWithoutGroupID(ctx, mc, &currentDeploy.Spec.Template, c.component, true)
 	needUpdate := c.util.RenewDeployAnnotation(ctx, mc, currentDeploy)
-	if c.util.IsPodTemplateChanged(ctx, currentDeploy, podTemplate) {
+	if templateChanged {
 		needUpdate = true
 		updatePodTemplateTwoDeployMode(ctx, c.component, currentDeploy, podTemplate)
 	}

--- a/pkg/controllers/deploy_ctrl_test.go
+++ b/pkg/controllers/deploy_ctrl_test.go
@@ -555,11 +555,22 @@ func TestDeployControllerBizImpl_HandleManualMode(t *testing.T) {
 		assert.Equal(t, ErrRequeue, err)
 	})
 
-	t.Run("active deploy has replica, no new rollout", func(t *testing.T) {
+	t.Run("active deploy has replica and template is unchanged", func(t *testing.T) {
 		deploy.Spec.Replicas = int32Ptr(1)
 		mockUtil.EXPECT().GetDeploys(ctx, mc).Return(deploy, nil, nil)
+		mockUtil.EXPECT().RenderPodTemplateWithoutGroupID(gomock.Any(), mc, gomock.Any(), QueryNode, true).Return(podTemplate)
+		mockUtil.EXPECT().IsPodTemplateChanged(gomock.Any(), deploy, podTemplate).Return(false)
 		err := bizImpl.HandleManualMode(ctx, mc)
 		assert.NoError(t, err)
 	})
 
+	t.Run("active deploy has replica and template drift", func(t *testing.T) {
+		deploy.Spec.Replicas = int32Ptr(1)
+		mockUtil.EXPECT().GetDeploys(ctx, mc).Return(deploy, nil, nil)
+		mockUtil.EXPECT().RenderPodTemplateWithoutGroupID(gomock.Any(), mc, gomock.Any(), QueryNode, true).Return(podTemplate)
+		mockUtil.EXPECT().IsPodTemplateChanged(gomock.Any(), deploy, podTemplate).Return(true)
+		err := bizImpl.HandleManualMode(ctx, mc)
+		assert.ErrorIs(t, err, ErrRequeue)
+		assert.Contains(t, err.Error(), "active deployment pod template is out of sync")
+	})
 }


### PR DESCRIPTION
## Summary
- render the desired pod template before the active-deployment early return in manual mode
- return `ErrRequeue` when a Deployment with replicas is still using a stale pod template
- keep the existing no-op behavior when the active template already matches

## Why
Manual mode previously returned success as soon as the active Deployment had replicas. That allowed reconciliation status to advance without detecting that the new Milvus component template had not been applied.

The guard intentionally does not mutate an active Deployment. It blocks status advancement until the workflow safely brings the Deployment back to zero replicas and the template can be updated.

## Tests
- `go test ./pkg/controllers -run ^TestDeployControllerBizImpl_HandleManualMode$ -count=1`
- `git diff --check`