### PR TITLE
chore: bump milvus operator versions to v1.3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 1.3.8
+VERSION ?= 1.3.9
 TOOL_VERSION ?= 1.0.0
 MILVUS_HELM_VERSION ?= milvus-5.0.26
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ helm -n milvus-operator upgrade --install --create-namespace milvus-operator mil
 Or with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.8/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.9/deploy/manifests/deployment.yaml
 ```
 
 For more information Check [Installation Instructions](docs/installation/installation.md)
@@ -135,11 +135,11 @@ Use helm:
 ```shell
 helm upgrade --install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.8/milvus-operator-1.3.8.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.9/milvus-operator-1.3.9.tgz
 ```
 
 Or use kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.8/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.9/deploy/manifests/deployment.yaml
 ```

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.8
+version: 1.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.8"
+appVersion: "1.3.9"
 
 dependencies:
   - name: cert-manager

--- a/charts/milvus-operator/templates/crds.yaml
+++ b/charts/milvus-operator/templates/crds.yaml
@@ -3098,6 +3098,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -4607,6 +4617,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -8710,6 +8730,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -16594,6 +16624,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -18103,6 +18143,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -22206,6 +22256,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v1.3.8"
+  tag: "v1.3.9"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-1.3.8
+    helm.sh/chart: milvus-operator-1.3.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.8"
+    app.kubernetes.io/version: "1.3.9"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -3116,6 +3116,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -4625,6 +4635,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -8728,6 +8748,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -16613,6 +16643,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -18122,6 +18162,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -22225,6 +22275,16 @@ spec:
                           type: object
                         type: array
                         x-kubernetes-preserve-unknown-fields: true
+                      statefulSet:
+                        properties:
+                          enabled:
+                            type: boolean
+                          volumeClaimTemplates:
+                            items:
+                              type: object
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       tolerations:
                         items:
                           properties:
@@ -26147,10 +26207,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-1.3.8
+    helm.sh/chart: milvus-operator-1.3.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.8"
+    app.kubernetes.io/version: "1.3.9"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -26168,10 +26228,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-1.3.8
+    helm.sh/chart: milvus-operator-1.3.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "1.3.8"
+    app.kubernetes.io/version: "1.3.9"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -26202,7 +26262,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v1.3.8'
+        image: 'milvusdb/milvus-operator:v1.3.9'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,7 +12,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.8/milvus-operator-1.3.8.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.9/milvus-operator-1.3.9.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -20,7 +20,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.8/milvus-operator-1.3.8.tgz \
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.9/milvus-operator-1.3.9.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -39,7 +39,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.8/milvus-operator-1.3.8.tgz
+  https://github.com/zilliztech/milvus-operator/releases/download/v1.3.9/milvus-operator-1.3.9.tgz
 ```
 
 ## Delete operator
@@ -62,7 +62,7 @@ If you don't want to use helm you can also install with kubectl and raw manifest
 ## Installation
 It is recommended to install the milvus operator with a newest stable version
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.8/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.9/deploy/manifests/deployment.yaml
 ``` 
 
 Check the installed operators:
@@ -85,7 +85,7 @@ Same as installation, you can update the milvus operator with a newer version by
 Delete the milvus operator stack by the deployment manifest:
 
 ```shell
-kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.8/deploy/manifests/deployment.yaml
+kubectl delete -f https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.9/deploy/manifests/deployment.yaml
 ```
 
 Or delete the milvus operator stack by using makefile:


### PR DESCRIPTION
Bump milvus-operator version to v1.3.9. Milvus remains at v2.6.11 and milvus-helm remains at milvus-5.0.26 (via scripts/bump-version.sh).

Note: this also regenerates the chart CRDs and deploy/manifests/deployment.yaml, picking up the StatefulSet fields from #512 that were missing from the generated chart manifest.

Validation:
- make deploy-manifests
- helm lint charts/milvus-operator
- git diff --check