### PR TITLE
fix: skip StatefulSet PVC expansion on non-expandable StorageClass

### DIFF
--- a/charts/milvus-operator/templates/clusterrole.yaml
+++ b/charts/milvus-operator/templates/clusterrole.yaml
@@ -26,6 +26,13 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
   - apps
   - extensions
   resources:
@@ -162,5 +169,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 {{- end -}}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,6 +25,13 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
   - apps
   - extensions
   resources:
@@ -161,4 +168,12 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch

--- a/pkg/controllers/common_test.go
+++ b/pkg/controllers/common_test.go
@@ -6,9 +6,11 @@ import (
 
 	"go.uber.org/mock/gomock"
 	"helm.sh/helm/v3/pkg/cli"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/zilliztech/milvus-operator/apis/milvus.io/v1beta1"
@@ -58,6 +60,7 @@ func newMilvusReconcilerForTest(ctrl *gomock.Controller) *MilvusReconciler {
 	logger := ctrlRuntime.Log.WithName("test")
 	scheme := runtime.NewScheme()
 	v1beta1.AddToScheme(scheme)
+	storagev1.AddToScheme(scheme)
 	helmSetting := cli.New()
 
 	mockManager := NewMockManager(ctrl)
@@ -75,6 +78,7 @@ func newMilvusReconcilerForTest(ctrl *gomock.Controller) *MilvusReconciler {
 		logger:         logger,
 		Scheme:         scheme,
 		helmReconciler: helmReconciler,
+		record:         record.NewFakeRecorder(100),
 	}
 	return &r
 }

--- a/pkg/controllers/milvus_controller.go
+++ b/pkg/controllers/milvus_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,7 @@ type MilvusReconciler struct {
 	helmReconciler HelmReconciler
 	statusSyncer   MilvusStatusSyncerInterface
 	deployCtrl     DeployController
+	record         record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=milvus.io,resources=milvuses,verbs=get;list;watch;create;update;patch;delete
@@ -63,11 +65,13 @@ type MilvusReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets;controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods;pods/exec;configmaps;serviceaccounts;secrets;services;persistentvolumeclaims;persistentvolumes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets;podsecuritypolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;get;watch
+//+kubebuilder:rbac:groups="storage.k8s.io",resources=storageclasses,verbs=get;list;watch
 
 // below wrong statements are introduced by pulsar helm chart. we have to keep them before pulsar fixes.
 //+kubebuilder:rbac:groups="";extensions;apps,resources=statefulsets;deployments;pods;secrets;services;ingresses,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/setup.go
+++ b/pkg/controllers/setup.go
@@ -52,6 +52,7 @@ func SetupControllers(ctx context.Context, mgr manager.Manager, stopReconcilers 
 			logger:         logger.WithName("milvus"),
 			helmReconciler: helmReconciler,
 			statusSyncer:   statusSyncer,
+			record:         mgr.GetEventRecorderFor("milvus-operator"),
 		}
 		k8sUtil := NewK8sUtil(mgr.GetClient())
 		bizUtilFactory := NewDeployControllerBizUtilFactory(mgr.GetClient(), k8sUtil)

--- a/pkg/controllers/statefulset.go
+++ b/pkg/controllers/statefulset.go
@@ -7,10 +7,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -279,11 +282,14 @@ func matchStatefulSetPVCOrdinal(pvcName string, prefixes []string) (int32, bool)
 // storage request in a volumeClaimTemplate increases. StatefulSet's
 // volumeClaimTemplates are immutable after creation, so the operator patches the
 // existing PVC objects directly (only expansion — shrink is rejected by
-// Kubernetes and skipped here). Whether the patch actually resizes the volume is
+// Kubernetes and skipped here). Whether the volume can be resized at all is
 // decided by the StorageClass: networked storage with allowVolumeExpansion grows
 // online without restarting pods; storage that cannot expand (e.g. local-SSD)
-// rejects the patch, which is logged and left for the operator to resolve rather
-// than retried in a tight loop.
+// would reject the patch. To avoid retrying a write the API server will reject on
+// every reconcile, the operator first checks the target StorageClass's
+// allowVolumeExpansion and skips the update (emitting a Warning event) when
+// expansion is unsupported. The check is re-evaluated each reconcile, so enabling
+// expansion support later lets the expansion proceed on its own.
 func (r *MilvusReconciler) reconcileStatefulSetPVCExpansion(ctx context.Context, mc v1beta1.Milvus, component MilvusComponent, sts *appsv1.StatefulSet) error {
 	if len(sts.Spec.VolumeClaimTemplates) == 0 {
 		return nil
@@ -312,6 +318,10 @@ func (r *MilvusReconciler) reconcileStatefulSetPVCExpansion(ctx context.Context,
 		return pkgerr.Wrap(err, "list querynode pvcs")
 	}
 
+	// StorageClass expansion support is cached per reconcile so a StatefulSet with
+	// many replicas resolves each class at most once.
+	expansionSupport := map[string]bool{}
+
 	// PVC name is "<templateName>-<stsName>-<ordinal>"; map each PVC back to its template.
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
@@ -339,6 +349,28 @@ func (r *MilvusReconciler) reconcileStatefulSetPVCExpansion(ctx context.Context,
 				"pvc", pvc.Name, "current", current.String(), "desired", desired.String())
 			continue
 		}
+
+		// Only issue the update when the StorageClass allows expansion; otherwise
+		// the API server rejects it and the next reconcile would retry the same
+		// rejected write. A StorageClass we cannot resolve (unknown/transient) is
+		// treated as expandable so the write is still attempted — the original
+		// best-effort behavior — and transient failures keep being retried.
+		scName := storageClassNameForPVC(pvc)
+		allowed, resolved := expansionSupport[scName]
+		if !resolved {
+			allowed = r.storageClassAllowsExpansion(ctx, scName)
+			expansionSupport[scName] = allowed
+		}
+		if !allowed {
+			logger.Info("Skip querynode pvc expansion; storage class does not allow volume expansion",
+				"pvc", pvc.Name, "storageClass", scName,
+				"current", current.String(), "desired", desired.String())
+			r.eventf(&mc, corev1.EventTypeWarning, "PVCExpansionUnsupported",
+				"skip expanding PVC %q from %s to %s: storage class %q does not allow volume expansion",
+				pvc.Name, current.String(), desired.String(), scName)
+			continue
+		}
+
 		logger.Info("Expand querynode pvc", "pvc", pvc.Name,
 			"current", current.String(), "desired", desired.String())
 		if pvc.Spec.Resources.Requests == nil {
@@ -346,13 +378,63 @@ func (r *MilvusReconciler) reconcileStatefulSetPVCExpansion(ctx context.Context,
 		}
 		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = desired
 		if err := r.Update(ctx, pvc); err != nil {
-			// StorageClasses that cannot expand (e.g. local-SSD) reject this.
-			// Surface it but do not fail the whole reconcile.
-			logger.Error(err, "failed to expand querynode pvc; storage may not support expansion",
+			// A transient failure here is retried on the next reconcile.
+			logger.Error(err, "failed to expand querynode pvc",
 				"pvc", pvc.Name, "desired", desired.String())
+			r.eventf(&mc, corev1.EventTypeWarning, "PVCExpansionFailed",
+				"failed to expand PVC %q to %s: %v", pvc.Name, desired.String(), err)
 		}
 	}
 	return nil
+}
+
+// storageClassNameForPVC returns the StorageClass name bound to a PVC. An empty
+// string means the PVC targets the cluster's default StorageClass (or none).
+func storageClassNameForPVC(pvc *corev1.PersistentVolumeClaim) string {
+	if pvc.Spec.StorageClassName != nil {
+		return *pvc.Spec.StorageClassName
+	}
+	return ""
+}
+
+// storageClassAllowsExpansion reports whether volumes provisioned by the named
+// StorageClass can be expanded. When the name is empty it resolves the cluster's
+// default StorageClass. It returns true when the class cannot be resolved (not
+// found, unlabeled default, or a transient API error), so expansion is still
+// attempted and transient lookup failures do not permanently block a resize.
+func (r *MilvusReconciler) storageClassAllowsExpansion(ctx context.Context, name string) bool {
+	logger := ctrl.LoggerFrom(ctx)
+	sc := &storagev1.StorageClass{}
+	if name != "" {
+		if err := r.Get(ctx, types.NamespacedName{Name: name}, sc); err != nil {
+			logger.Error(err, "resolve storage class for pvc expansion; assuming expansion allowed", "storageClass", name)
+			return true
+		}
+		return sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion
+	}
+
+	// No StorageClass name on the PVC: fall back to the cluster default.
+	scList := &storagev1.StorageClassList{}
+	if err := r.List(ctx, scList); err != nil {
+		logger.Error(err, "list storage classes for pvc expansion; assuming expansion allowed")
+		return true
+	}
+	for i := range scList.Items {
+		if scList.Items[i].Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return scList.Items[i].AllowVolumeExpansion != nil && *scList.Items[i].AllowVolumeExpansion
+		}
+	}
+	// No default StorageClass found; cannot decide, so attempt the expansion.
+	return true
+}
+
+// eventf records a Kubernetes event when an event recorder is configured. The
+// recorder is nil in some unit tests, so callers use this to stay nil-safe.
+func (r *MilvusReconciler) eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
+	if r.record == nil {
+		return
+	}
+	r.record.Eventf(object, eventtype, reason, messageFmt, args...)
 }
 
 // reconcileStatefulSetService ensures a headless service exists so the

--- a/pkg/controllers/statefulset_test.go
+++ b/pkg/controllers/statefulset_test.go
@@ -11,10 +11,12 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/zilliztech/milvus-operator/apis/milvus.io/v1beta1"
@@ -468,18 +470,31 @@ func TestReconcileQueryNodePVCExpansion(t *testing.T) {
 		sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "qn-data"}}}
 		return sts
 	}
+	scName := "test-sc"
 	existingPVC := func(size string) corev1.PersistentVolumeClaim {
+		sc := scName
 		return corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: "qn-data-" + stsName + "-0", Namespace: "ns"},
 			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &sc,
 				Resources: corev1.VolumeResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
 				},
 			},
 		}
 	}
+	// expectStorageClass mocks the Get(StorageClass) the expansion path issues to
+	// decide whether the target class allows volume expansion.
+	expectStorageClass := func(mockClient *MockK8sClient, allowExpansion bool) {
+		mockClient.EXPECT().
+			Get(gomock.Any(), types.NamespacedName{Name: scName}, gomock.AssignableToTypeOf(&storagev1.StorageClass{}), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...any) error {
+				obj.(*storagev1.StorageClass).AllowVolumeExpansion = &allowExpansion
+				return nil
+			})
+	}
 
-	t.Run("expands when desired greater", func(t *testing.T) {
+	t.Run("expands when desired greater and storage class allows it", func(t *testing.T) {
 		env := newTestEnv(t)
 		defer env.checkMocks()
 		r := env.Reconciler
@@ -490,6 +505,51 @@ func TestReconcileQueryNodePVCExpansion(t *testing.T) {
 				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("100Gi")}
 				return nil
 			})
+		expectStorageClass(mockClient, true)
+		var patched resource.Quantity
+		mockClient.EXPECT().
+			Update(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{})).
+			DoAndReturn(func(_ context.Context, obj client.Object, _ ...any) error {
+				patched = obj.(*corev1.PersistentVolumeClaim).Spec.Resources.Requests[corev1.ResourceStorage]
+				return nil
+			})
+		err := r.reconcileStatefulSetPVCExpansion(env.ctx, newMc("200Gi"), QueryNode, newSts())
+		assert.NoError(t, err)
+		assert.Equal(t, "200Gi", patched.String())
+	})
+
+	t.Run("skips expansion when storage class does not allow it", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.checkMocks()
+		r := env.Reconciler
+		mockClient := env.MockClient
+		mockClient.EXPECT().
+			List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, raw client.ObjectList, _ ...any) error {
+				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("100Gi")}
+				return nil
+			})
+		expectStorageClass(mockClient, false)
+		// no Update expected: the operator must not issue a write the API server
+		// would reject, so the next reconcile does not retry it either.
+		err := r.reconcileStatefulSetPVCExpansion(env.ctx, newMc("200Gi"), QueryNode, newSts())
+		assert.NoError(t, err)
+	})
+
+	t.Run("attempts expansion when storage class cannot be resolved", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.checkMocks()
+		r := env.Reconciler
+		mockClient := env.MockClient
+		mockClient.EXPECT().
+			List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, raw client.ObjectList, _ ...any) error {
+				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("100Gi")}
+				return nil
+			})
+		mockClient.EXPECT().
+			Get(gomock.Any(), types.NamespacedName{Name: scName}, gomock.AssignableToTypeOf(&storagev1.StorageClass{}), gomock.Any()).
+			Return(k8sErrors.NewNotFound(schema.GroupResource{Resource: "storageclasses"}, scName))
 		var patched resource.Quantity
 		mockClient.EXPECT().
 			Update(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{})).
@@ -513,7 +573,7 @@ func TestReconcileQueryNodePVCExpansion(t *testing.T) {
 				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("100Gi")}
 				return nil
 			})
-		// no Update expected
+		// no StorageClass lookup and no Update expected
 		err := r.reconcileStatefulSetPVCExpansion(env.ctx, newMc("100Gi"), QueryNode, newSts())
 		assert.NoError(t, err)
 	})
@@ -529,12 +589,12 @@ func TestReconcileQueryNodePVCExpansion(t *testing.T) {
 				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("200Gi")}
 				return nil
 			})
-		// no Update expected (shrink skipped)
+		// no StorageClass lookup and no Update expected (shrink skipped)
 		err := r.reconcileStatefulSetPVCExpansion(env.ctx, newMc("100Gi"), QueryNode, newSts())
 		assert.NoError(t, err)
 	})
 
-	t.Run("patch failure is non-fatal", func(t *testing.T) {
+	t.Run("transient patch failure is non-fatal and retried", func(t *testing.T) {
 		env := newTestEnv(t)
 		defer env.checkMocks()
 		r := env.Reconciler
@@ -545,10 +605,12 @@ func TestReconcileQueryNodePVCExpansion(t *testing.T) {
 				raw.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{existingPVC("100Gi")}
 				return nil
 			})
+		expectStorageClass(mockClient, true)
 		mockClient.EXPECT().
 			Update(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{})).
-			Return(errors.New("storageclass does not allow expansion"))
-		// error is logged, not returned
+			Return(errors.New("etcdserver: request timed out"))
+		// error is logged (and an event emitted), not returned, so the reconcile
+		// retries on the next pass.
 		err := r.reconcileStatefulSetPVCExpansion(env.ctx, newMc("200Gi"), QueryNode, newSts())
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
When a volumeClaimTemplate storage increase targets a StorageClass whose allowVolumeExpansion is false, the PVC update is rejected by the API server, and every subsequent reconcile retried the same rejected write, producing repeated errors.

Before issuing the PVC update, resolve the target StorageClass and check allowVolumeExpansion. When expansion is unsupported, skip the write and emit a PVCExpansionUnsupported Warning event instead of looping on a rejected update. The check is re-evaluated each reconcile (cached per reconcile so N replicas resolve a class at most once), so enabling expansion support later lets the resize proceed on its own. Unresolvable or transient StorageClass lookups fall back to attempting the write, preserving the previous best-effort behavior, and genuine transient update failures still surface a PVCExpansionFailed event and are retried.

Adds a StorageClass (get/list/watch) and events (create/patch) RBAC rule for the new lookups and event recorder, plus tests covering supported, unsupported, and unresolvable StorageClasses.

Fixes #516