### PR TITLE
fix: improve diagnostics for StatefulSet-backed components

### DIFF
--- a/pkg/controllers/component_condition.go
+++ b/pkg/controllers/component_condition.go
@@ -52,12 +52,18 @@ func (c ComponentConditionGetterImpl) GetMilvusInstanceCondition(ctx context.Con
 		if componentUsesStatefulSet(mc, component) {
 			sts, err := getStatefulSetForComponent(ctx, cli, mc, component)
 			if err != nil {
-				return v1beta1.MilvusCondition{}, errors.Wrap(err, "get querynode statefulset")
+				return v1beta1.MilvusCondition{}, errors.Wrapf(err, "get %s statefulset", component.Name)
 			}
 			if sts != nil && DeploymentReady(synthesizeStatefulSetStatus(component, sts).Status) {
 				continue
 			}
 			notReadyComponents = append(notReadyComponents, component.GetDisplayName())
+			if errDetail == nil {
+				errDetail, err = getStatefulSetErrorDetail(ctx, cli, component.GetDisplayName(), sts)
+				if err != nil {
+					return v1beta1.MilvusCondition{}, errors.Wrap(err, "failed to get component err detail")
+				}
+			}
 			continue
 		}
 		deployment := componentDeploy[component.GetStateKey()]
@@ -147,30 +153,62 @@ var getComponentErrorDetail = func(ctx context.Context, cli client.Client, compo
 		return ret, err
 	}
 
+	if err := collectPodErrorDetail(ctx, cli, ret, deploy.Namespace, deploy.Spec.Selector.MatchLabels); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// getStatefulSetErrorDetail collects the same pod/container-level diagnostics as
+// getComponentErrorDetail for a StatefulSet-backed component, so an unready
+// StatefulSet reports a real reason instead of <nil>. StatefulSet has no
+// Deployment-style conditions, so only the pod-level detail is populated.
+var getStatefulSetErrorDetail = func(ctx context.Context, cli client.Client, component string, sts *appsv1.StatefulSet) (*ComponentErrorDetail, error) {
+	ret := &ComponentErrorDetail{ComponentName: component, WorkloadKind: "statefulset"}
+	if sts == nil {
+		return ret, nil
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		ret.NotObserved = true
+		return ret, nil
+	}
+	if sts.Spec.Selector == nil {
+		return ret, nil
+	}
+	if err := collectPodErrorDetail(ctx, cli, ret, sts.Namespace, sts.Spec.Selector.MatchLabels); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// collectPodErrorDetail finds the first not-ready pod matching the selector and
+// records its condition and first not-ready container into ret. Shared by the
+// Deployment and StatefulSet error-detail paths.
+func collectPodErrorDetail(ctx context.Context, cli client.Client, ret *ComponentErrorDetail, namespace string, selector map[string]string) error {
 	pods := &corev1.PodList{}
 	opts := &client.ListOptions{
-		Namespace: deploy.Namespace,
+		Namespace: namespace,
 	}
-	opts.LabelSelector = labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels)
+	opts.LabelSelector = labels.SelectorFromSet(selector)
 	if err := cli.List(ctx, pods, opts); err != nil {
-		return nil, errors.Wrap(err, "list pods")
+		return errors.Wrap(err, "list pods")
 	}
 	if len(pods.Items) == 0 {
-		return ret, nil
+		return nil
 	}
 	for _, pod := range pods.Items {
 		if !PodReady(pod) {
 			podCondition, err := GetPodFalseCondition(pod)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			ret.PodName = pod.Name
 			ret.Pod = podCondition
 			ret.Container = getFirstNotReadyContainerStatus(pod.Status.ContainerStatuses)
-			return ret, nil
+			return nil
 		}
 	}
-	return ret, nil
+	return nil
 }
 
 func GetComponentConditionGetter() ComponentConditionGetter {

--- a/pkg/controllers/component_condition_test.go
+++ b/pkg/controllers/component_condition_test.go
@@ -282,6 +282,60 @@ func TestComponentConditionGetter_GetMilvusInstanceCondition(t *testing.T) {
 		assert.Equal(t, corev1.ConditionFalse, ret.Status)
 	})
 
+	t.Run("querynode statefulset not ready reports pod detail", func(t *testing.T) {
+		stsInst := &v1beta1.Milvus{ObjectMeta: metav1.ObjectMeta{Namespace: "nssts3", Name: "mcsts3", UID: "uidsts3"}}
+		stsInst.Spec.Mode = v1beta1.MilvusModeCluster
+		stsInst.Default()
+		stsInst.Spec.Com.QueryNode.StatefulSet = &v1beta1.ComponentStatefulSet{Enabled: true}
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DeploymentList{}), gomock.Any()).
+			Do(func(_ interface{}, list *appsv1.DeploymentList, _ interface{}) {
+				for _, c := range Milvus2_6Components {
+					if c.Is(QueryNode) {
+						continue
+					}
+					d := appsv1.Deployment{}
+					d.Labels = map[string]string{AppLabelComponent: c.Name}
+					d.OwnerReferences = []metav1.OwnerReference{{Controller: &trueVal, UID: "uidsts3"}}
+					d.Status = readyDeployStatus
+					list.Items = append(list.Items, d)
+				}
+			}).Return(nil)
+		// querynode STS exists but is not ready (observed, 0 ready replicas).
+		mockClient.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).
+			DoAndReturn(func(_ context.Context, key client.ObjectKey, obj client.Object, _ ...any) error {
+				sts := obj.(*appsv1.StatefulSet)
+				sts.Name = key.Name
+				sts.Namespace = key.Namespace
+				sts.Generation = 1
+				one := int32(1)
+				sts.Spec.Replicas = &one
+				sts.Spec.Selector = &metav1.LabelSelector{MatchLabels: QueryNode.GetSelectorLabels(stsInst.Name)}
+				sts.Status.ObservedGeneration = 1
+				sts.Status.ReadyReplicas = 0
+				return nil
+			})
+		// pod list for the STS error detail: one pod stuck pulling its image.
+		mockClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.PodList{}), gomock.Any()).
+			DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+				pod := corev1.Pod{}
+				pod.Name = "mcsts3-milvus-querynode-0"
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  QueryNode.Name,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+				}}
+				list.(*corev1.PodList).Items = []corev1.Pod{pod}
+				return nil
+			})
+		ret, err := GetComponentConditionGetter().GetMilvusInstanceCondition(ctx, mockClient, *stsInst)
+		assert.NoError(t, err)
+		assert.Equal(t, corev1.ConditionFalse, ret.Status)
+		// message names the component and carries pod/container detail, not <nil>
+		assert.Contains(t, ret.Message, "querynode")
+		assert.Contains(t, ret.Message, "ImagePullBackOff")
+		assert.NotContains(t, ret.Message, "detail: <nil>")
+	})
+
 }
 
 func TestGetComponentErrorDetail(t *testing.T) {
@@ -370,6 +424,71 @@ func TestGetComponentErrorDetail(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "creating", ret.Deployment.Message)
 	})
+}
+
+func TestGetStatefulSetErrorDetail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+	cli := NewMockK8sClient(ctrl)
+
+	newSts := func(component string) *appsv1.StatefulSet {
+		sts := &appsv1.StatefulSet{}
+		sts.Namespace = "ns"
+		sts.Name = "mc-milvus-" + component
+		sts.Generation = 1
+		sts.Status.ObservedGeneration = 1
+		sts.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{AppLabelComponent: component},
+		}
+		return sts
+	}
+
+	t.Run("statefulset nil", func(t *testing.T) {
+		ret, err := getStatefulSetErrorDetail(ctx, cli, "querynode", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "querynode", ret.ComponentName)
+		assert.Equal(t, "statefulset", ret.WorkloadKind)
+		// non-pod fallback reports the StatefulSet noun, not "deployment"
+		assert.Equal(t, "component[querynode]: statefulset not created", ret.String())
+	})
+
+	t.Run("new generation not observed", func(t *testing.T) {
+		sts := newSts("datanode")
+		sts.Status.ObservedGeneration = 0
+		ret, err := getStatefulSetErrorDetail(ctx, cli, "datanode", sts)
+		assert.NoError(t, err)
+		assert.True(t, ret.NotObserved)
+		assert.Equal(t, "component[datanode]: updating statefulset", ret.String())
+	})
+
+	// One case per StatefulSet-capable component, asserting real pod/container
+	// detail is surfaced instead of <nil>.
+	for _, component := range []string{"querynode", "datanode", "indexnode"} {
+		t.Run(component+" pod image pull failure", func(t *testing.T) {
+			sts := newSts(component)
+			pod := corev1.Pod{}
+			pod.Name = sts.Name + "-0"
+			pod.Namespace = "ns"
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name: component,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+				},
+			}}
+			cli.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), gomock.Any()).
+				DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					list.(*corev1.PodList).Items = []corev1.Pod{pod}
+					return nil
+				})
+			ret, err := getStatefulSetErrorDetail(ctx, cli, component, sts)
+			assert.NoError(t, err)
+			assert.Equal(t, component, ret.ComponentName)
+			assert.Equal(t, pod.Name, ret.PodName)
+			assert.NotNil(t, ret.Container)
+			assert.Contains(t, ret.String(), "ImagePullBackOff")
+		})
+	}
 }
 
 func TestExecKillIfTerminatingTooLong(t *testing.T) {

--- a/pkg/controllers/error_detail.go
+++ b/pkg/controllers/error_detail.go
@@ -15,15 +15,22 @@ const (
 // ComponentErrorDetail is one sample of error detail among all error pods
 type ComponentErrorDetail struct {
 	ComponentName string
-	NotObserved   bool
-	Deployment    *appsv1.DeploymentCondition
-	PodName       string
-	Pod           *corev1.PodCondition
-	Container     *corev1.ContainerStatus
+	// WorkloadKind is the noun used in the non-pod fallback messages ("deployment"
+	// or "statefulset"). Empty defaults to "deployment" for backward compatibility.
+	WorkloadKind string
+	NotObserved  bool
+	Deployment   *appsv1.DeploymentCondition
+	PodName      string
+	Pod          *corev1.PodCondition
+	Container    *corev1.ContainerStatus
 }
 
 func (m ComponentErrorDetail) String() string {
 	ret := fmt.Sprintf("component[%s]: ", m.ComponentName)
+	workload := m.WorkloadKind
+	if workload == "" {
+		workload = "deployment"
+	}
 	if m.Pod != nil {
 		ret += fmt.Sprintf("pod[%s]: ", m.PodName)
 		if m.Container != nil {
@@ -33,11 +40,11 @@ func (m ComponentErrorDetail) String() string {
 		}
 	} else {
 		if m.NotObserved {
-			ret += "updating deployment"
+			ret += "updating " + workload
 			return ret
 		}
 		if m.Deployment == nil {
-			return ret + "deployment not created"
+			return ret + workload + " not created"
 		}
 		ret += fmt.Sprintf("deployment status[%s:%s]: reason[%s]: %s", m.Deployment.Type, m.Deployment.Status, m.Deployment.Reason, m.Deployment.Message)
 	}

--- a/pkg/controllers/error_detail_test.go
+++ b/pkg/controllers/error_detail_test.go
@@ -75,6 +75,48 @@ func TestComponentErrorDetail_String(t *testing.T) {
 			"component[proxy]: pod[myrelease-proxy-xxxx-xxxx]: container[main]: currentState[waiting] reason[ErrImagePull]: ...",
 			detail.String())
 	})
+
+	t.Run("statefulset not created", func(t *testing.T) {
+		detail := ComponentErrorDetail{
+			ComponentName: "querynode",
+			WorkloadKind:  "statefulset",
+		}
+		assert.Equal(t, "component[querynode]: statefulset not created", detail.String())
+	})
+
+	t.Run("statefulset new generation not observed", func(t *testing.T) {
+		detail := ComponentErrorDetail{
+			ComponentName: "datanode",
+			WorkloadKind:  "statefulset",
+			NotObserved:   true,
+		}
+		assert.Equal(t, "component[datanode]: updating statefulset", detail.String())
+	})
+
+	t.Run("statefulset pod pull image failed", func(t *testing.T) {
+		detail := ComponentErrorDetail{
+			ComponentName: "indexnode",
+			WorkloadKind:  "statefulset",
+			PodName:       "mc-milvus-indexnode-0",
+			Pod: &corev1.PodCondition{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+			},
+			Container: &corev1.ContainerStatus{
+				Name: "indexnode",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: "ImagePullBackOff",
+					},
+				},
+			},
+		}
+		// pod/container detail is workload-agnostic; the StatefulSet noun only
+		// affects the non-pod fallback branches.
+		assert.Equal(t,
+			"component[indexnode]: pod[mc-milvus-indexnode-0]: container[indexnode]: currentState[waiting] reason[ImagePullBackOff]",
+			detail.String())
+	})
 }
 
 func TestGetDeploymentFalseCondition(t *testing.T) {

--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -506,7 +506,7 @@ func (r *componentsDeployStatusUpdaterImpl) Update(ctx context.Context, mc *v1be
 		if componentUsesStatefulSet(*mc, workload) {
 			sts, err := getStatefulSetForComponent(ctx, r.Client, *mc, workload)
 			if err != nil {
-				return errors.Wrap(err, "get querynode statefulset")
+				return errors.Wrapf(err, "get %s statefulset", workload.Name)
 			}
 			if sts == nil {
 				continue


### PR DESCRIPTION
The StatefulSet readiness path added for QueryNode/DataNode/IndexNode had two diagnostic gaps (reconciliation and rolling-update safety were unaffected):

1. A failed StatefulSet fetch was wrapped with the literal "get querynode statefulset" regardless of the actual component, in both the readiness condition path and the deploy-status updater.
2. The readiness path appended the component name for an unready StatefulSet-backed component but skipped the pod/container-level detail the Deployment path collects, so MilvusReady=False reported "detail: <nil>".

Report the actual component name on fetch failure, and collect the same pod/container error detail for StatefulSets by extracting the shared pod-scanning logic into collectPodErrorDetail and adding getStatefulSetErrorDetail. ComponentErrorDetail gains a WorkloadKind field so the non-pod fallback messages read "statefulset ..." instead of "deployment ..."; it defaults to "deployment" so existing output is unchanged. Adds focused tests covering QueryNode, DataNode and IndexNode.

Fixes #515